### PR TITLE
Check for wrapped lines first, then check for new tags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 
 branches:
   only:
-    - master
+    - main
     - develop
 
 after_success:

--- a/src/Bag.php
+++ b/src/Bag.php
@@ -1190,12 +1190,16 @@ class Bag
             while (!feof($fp)) {
                 $line = fgets($fp);
                 $lineCount += 1;
-                if ($line == "") {
+                if (trim($line) == "") {
                     continue;
                 }
                 $line = $this->decodeText($line);
-
-                if (preg_match("~^(\s+)?([^:]+?)(\s+)?:\s+(.*)$~", $line, $matches)) {
+                if (!empty($line) && (substr($line, 0, 2) == "  " || $line[0] == "\t")) {
+                    // Continuation of a line
+                    if (count($bagData) > 0) {
+                        $bagData[count($bagData)-1]['value'] .= " " . trim($line);
+                    }
+                } elseif (preg_match("~^(\s+)?([^:]+?)(\s+)?:\s+(.*)$~", $line, $matches)) {
                     // First line
                     $current_tag = $matches[2];
                     if ($this->mustNotRepeatBagInfoExists($current_tag)) {
@@ -1219,10 +1223,6 @@ class Bag
                         'tag' => $current_tag,
                         'value' => trim($matches[4]),
                     ];
-                } elseif (!empty($line) && ($line[0] == " " || $line[0] == "\t")) {
-                    if (count($bagData) > 0) {
-                        $bagData[count($bagData)-1]['value'] .= " " . trim($line);
-                    }
                 } elseif (!empty($line)) {
                     $this->addBagError($info_file, "Invalid tag.");
                 }

--- a/tests/BagTest.php
+++ b/tests/BagTest.php
@@ -909,21 +909,4 @@ class BagTest extends BagItTestFramework
         $bag = Bag::load($this->tmpdir);
         $this->assertCount(1, $bag->getErrors());
     }
-
-    /**
-     * Test that long tag lines might contain colons and should still validate if
-     * @group Bag
-     * @covers ::loadBagInfo
-     */
-    public function testLongBagInfoLinesWrap()
-    {
-        $bag = Bag::create($this->tmpdir);
-        $bag->setExtended(true);
-
-        $bag->addBagInfoTag('Title', 'A really long long long long long long long long long long long ' .
-            'title with a colon : between and more information are on the way');
-
-        $bag->update();
-        $this->assertTrue($bag->validate());
-    }
 }

--- a/tests/BagTest.php
+++ b/tests/BagTest.php
@@ -909,4 +909,21 @@ class BagTest extends BagItTestFramework
         $bag = Bag::load($this->tmpdir);
         $this->assertCount(1, $bag->getErrors());
     }
+
+    /**
+     * Test that long tag lines might contain colons and should still validate if
+     * @group Bag
+     * @covers ::loadBagInfo
+     */
+    public function testLongBagInfoLinesWrap()
+    {
+        $bag = Bag::create($this->tmpdir);
+        $bag->setExtended(true);
+
+        $bag->addBagInfoTag('Title', 'A really long long long long long long long long long long long ' .
+            'title with a colon : between and more information are on the way');
+
+        $bag->update();
+        $this->assertTrue($bag->validate());
+    }
 }

--- a/tests/BagUtilsTest.php
+++ b/tests/BagUtilsTest.php
@@ -93,7 +93,7 @@ class BagUtilsTest extends BagItTestFramework
     public function testGetAllFiles()
     {
         $files = BagUtils::getAllFiles(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'bag-infos');
-        $this->assertCount(1, $files);
+        $this->assertCount(2, $files);
 
         $files = BagUtils::getAllFiles(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'fetchFiles');
         $this->assertCount(4, $files);

--- a/tests/ExtendedBagTest.php
+++ b/tests/ExtendedBagTest.php
@@ -497,6 +497,7 @@ class ExtendedBagTest extends BagItTestFramework
      * Test that long tag lines might contain colons and should still validate if
      * @group Extended
      * @covers ::loadBagInfo
+     * @covers ::trimSpacesOnly
      */
     public function testLongBagInfoLinesWrap()
     {
@@ -514,6 +515,7 @@ class ExtendedBagTest extends BagItTestFramework
      * Test loading long lines with internal newlines from a bag-info.txt
      * @group Extended
      * @covers ::loadBagInfo
+     * @covers ::trimSpacesOnly
      */
     public function testLoadWrappedLines()
     {

--- a/tests/ExtendedBagTest.php
+++ b/tests/ExtendedBagTest.php
@@ -492,4 +492,39 @@ class ExtendedBagTest extends BagItTestFramework
         $this->assertCount(1, $oxums);
         $this->assertEquals('1602921.5', $oxums[0]);
     }
+
+    /**
+     * Test that long tag lines might contain colons and should still validate if
+     * @group Extended
+     * @covers ::loadBagInfo
+     */
+    public function testLongBagInfoLinesWrap()
+    {
+        $bag = Bag::create($this->tmpdir);
+        $bag->setExtended(true);
+
+        $bag->addBagInfoTag('Title', 'A really long long long long long long long long long long long ' .
+            'title with a colon : between and more information are on the way');
+
+        $bag->update();
+        $this->assertTrue($bag->validate());
+    }
+
+    /**
+     * Test loading long lines with internal newlines from a bag-info.txt
+     * @group Extended
+     * @covers ::loadBagInfo
+     */
+    public function testLoadWrappedLines()
+    {
+        $bag = Bag::create($this->tmpdir);
+        copy(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'bag-infos' . DIRECTORY_SEPARATOR .
+            'long-lines-and-line-returns.txt', $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt');
+        touch($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
+
+        $testbag = Bag::load($this->tmpdir);
+        $this->assertCount(0, $testbag->getErrors());
+        $this->assertEquals("This is some crazy information\n about a new way of searching for : the " .
+            "stuff.\n Why do this? Because we can", $testbag->getBagInfoByTag('External-Description')[0]);
+    }
 }

--- a/tests/resources/bag-infos/long-lines-and-line-returns.txt
+++ b/tests/resources/bag-infos/long-lines-and-line-returns.txt
@@ -1,0 +1,4 @@
+Source-Organization: University of Manitoba
+External-Description: This is some crazy information
+  about a new way of searching for : the stuff.
+    Why do this? Because we can

--- a/tests/resources/bag-infos/long-lines-and-line-returns.txt
+++ b/tests/resources/bag-infos/long-lines-and-line-returns.txt
@@ -1,4 +1,4 @@
 Source-Organization: University of Manitoba
-External-Description: This is some crazy information
-  about a new way of searching for : the stuff.
-    Why do this? Because we can
+External-Description: This is some crazy information about a new way of searching for : the stuff.
+   Why do this?
+  Because we can.


### PR DESCRIPTION
Resolves: #17 

Reverse the tests to assume lines starting with at least 2 spaces or a tab character are the continuation of the previous line.
Otherwise start checking for a new tag.

@henning-gerhardt does this sound reasonable?