### PR TITLE
Check for issues with file operations and throw exception on errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: php
+os: linux
+dist: xenial
 
 php:
   - 7.2

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     "ext-intl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.7",
+    "phpunit/phpunit": "^7.0",
     "phpdocumentor/phpdocumentor": "^2.0",
-    "sebastian/phpcpd": "^3.0",
+    "sebastian/phpcpd": "^4.0",
     "squizlabs/php_codesniffer": "^3.5",
     "donatj/mock-webserver": "^2.1"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd126034618f447fbb0e3480fef0807c",
+    "content-hash": "83f83c691a2cd480544f664f89d392fc",
     "packages": [
         {
             "name": "pear/archive_tar",
@@ -428,16 +428,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.10.4",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f"
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/bfe91e31984e2ba76df1c1339681770401ec262f",
-                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
                 "shasum": ""
             },
             "require": {
@@ -447,13 +447,14 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
+                "doctrine/coding-standard": "^6.0 || ^8.1",
                 "phpstan/phpstan": "^0.12.20",
                 "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -488,13 +489,13 @@
                 }
             ],
             "description": "Docblock Annotations Parser",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
             "keywords": [
                 "annotations",
                 "docblock",
                 "parser"
             ],
-            "time": "2020-08-10T19:35:50+00:00"
+            "time": "2020-10-26T10:28:16+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1167,6 +1168,108 @@
             "time": "2018-03-30T12:52:15+00:00"
         },
         {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
             "name": "phpcollection/phpcollection",
             "version": "0.5.0",
             "source": {
@@ -1611,40 +1714,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "6.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^2.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -1659,7 +1762,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1670,29 +1773,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+00:00"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1707,7 +1813,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1717,7 +1823,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1762,28 +1868,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -1798,7 +1904,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1807,33 +1913,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -1857,55 +1963,57 @@
                 "tokenizer"
             ],
             "abandoned": true,
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2019-09-17T06:23:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.27",
+            "version": "7.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "^1.0.6|^2.0.1",
-                "symfony/yaml": "~2.1|~3.0|~4.0"
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1",
+                "sebastian/comparator": "^3.0",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^4.0",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0",
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -1913,7 +2021,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -1939,67 +2047,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-01T05:50:59+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2017-06-30T09:13:00+00:00"
+            "time": "2020-01-08T08:45:45+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -2324,30 +2372,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2378,38 +2426,39 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2434,34 +2483,40 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2486,34 +2541,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2019-11-20T08:46:58+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -2527,6 +2582,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -2535,16 +2594,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -2553,7 +2608,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/finder-facade",
@@ -2601,23 +2656,23 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -2625,7 +2680,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2648,33 +2703,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2694,25 +2750,71 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
-            "name": "sebastian/phpcpd",
-            "version": "3.0.1",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpcpd.git",
-                "reference": "dfed51c1288790fc957c9433e2f49ab152e8a564"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpcpd/zipball/dfed51c1288790fc957c9433e2f49ab152e8a564",
-                "reference": "dfed51c1288790fc957c9433e2f49ab152e8a564",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "phpunit/php-timer": "^1.0.6",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/phpcpd",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpcpd.git",
+                "reference": "0d9afa762f2400de077b2192f4a9d127de0bb78e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpcpd/zipball/0d9afa762f2400de077b2192f4a9d127de0bb78e",
+                "reference": "0d9afa762f2400de077b2192f4a9d127de0bb78e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^7.1",
+                "phpunit/php-timer": "^2.0",
                 "sebastian/finder-facade": "^1.1",
                 "sebastian/version": "^1.0|^2.0",
                 "symfony/console": "^2.7|^3.0|^4.0"
@@ -2723,7 +2825,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2744,32 +2846,32 @@
             ],
             "description": "Copy/Paste Detector (CPD) for PHP code.",
             "homepage": "https://github.com/sebastianbergmann/phpcpd",
-            "time": "2017-11-16T08:49:28+00:00"
+            "time": "2018-09-17T17:17:27+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2797,29 +2899,29 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2839,7 +2941,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2886,16 +2988,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.6",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -2933,7 +3035,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-08-10T04:50:15+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "symfony/config",
@@ -3270,20 +3372,20 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -3291,7 +3393,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3328,24 +3430,38 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a"
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/a6977d63bf9a0ad4c65cd352709e230876f9904a",
-                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -3353,7 +3469,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3391,7 +3507,21 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/process",
@@ -3630,61 +3760,6 @@
             "time": "2018-11-14T14:06:48+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.3.18",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "af615970e265543a26ee712c958404eb9b7ac93d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/af615970e265543a26ee712c958404eb9b7ac93d",
-                "reference": "af615970e265543a26ee712c958404eb9b7ac93d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "require-dev": {
-                "symfony/console": "~2.8|~3.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-01-20T15:04:53+00:00"
-        },
-        {
             "name": "theseer/fdomdocument",
             "version": "1.6.6",
             "source": {
@@ -3723,6 +3798,52 @@
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
             "time": "2017-06-30T11:53:12+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-12T23:59:07+00:00"
         },
         {
             "name": "twig/twig",
@@ -4580,5 +4701,6 @@
         "ext-mbstring": "*",
         "ext-intl": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/src/AbstractManifest.php
+++ b/src/AbstractManifest.php
@@ -3,7 +3,7 @@
 namespace whikloj\BagItTools;
 
 use whikloj\BagItTools\Exceptions\BagItException;
-use whikloj\BagItTools\Exceptions\SystemException;
+use whikloj\BagItTools\Exceptions\FilesystemException;
 
 /**
  * Abstract manifest class to hold common elements between Payload and Tag manifests.
@@ -149,7 +149,7 @@ abstract class AbstractManifest
     /**
      * Update the hashes for each path.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Error writing the manifest file to disk.
      */
     public function update()
@@ -222,7 +222,7 @@ abstract class AbstractManifest
     /**
      * Load the paths and hashes from the file on disk, does not validate.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Unable to read manifest file.
      */
     protected function loadFile()
@@ -233,7 +233,7 @@ abstract class AbstractManifest
         if (file_exists($fullPath)) {
             $fp = fopen($fullPath, "rb");
             if ($fp === false) {
-                throw new SystemException("Unable to read file {$fullPath}");
+                throw new FilesystemException("Unable to read file {$fullPath}");
             }
             $lineCount = 0;
             while (!feof($fp)) {
@@ -272,7 +272,7 @@ abstract class AbstractManifest
     /**
      * Utility to recreate the manifest file using the currently stored hashes.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   If we can't write the manifest files.
      */
     protected function writeToDisk()
@@ -283,7 +283,7 @@ abstract class AbstractManifest
         }
         $fp = fopen(addslashes($fullPath), "w");
         if ($fp === false) {
-            throw new SystemException("Unable to write {$fullPath}");
+            throw new FilesystemException("Unable to write {$fullPath}");
         }
         foreach ($this->hashes as $path => $hash) {
             $line = "{$hash} {$path}" . PHP_EOL;

--- a/src/Bag.php
+++ b/src/Bag.php
@@ -3,7 +3,7 @@
 namespace whikloj\BagItTools;
 
 use whikloj\BagItTools\Exceptions\BagItException;
-use whikloj\BagItTools\Exceptions\SystemException;
+use whikloj\BagItTools\Exceptions\FilesystemException;
 
 /**
  * Bag class as normal interface for all actions and holder of supporting constructs.
@@ -264,7 +264,7 @@ class Bag
      * @param boolean $new
      *   Are we making a new bag?
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems accessing a file.
      * @throws \whikloj\BagItTools\Exceptions\BagItException
      *   Bag directory exists for new bag or various issues for loading an existing bag.
@@ -363,7 +363,7 @@ class Bag
     /**
      * Write the updated BagIt files to disk.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Errors with writing files to disk.
      */
     public function update()
@@ -388,7 +388,7 @@ class Bag
     /**
      * This does cleanup functions related to packaging, for example deleting downloaded files referenced in fetch.txt
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues deleting files from filesystem.
      */
     public function finalize()
@@ -432,7 +432,7 @@ class Bag
      *
      * @throws \whikloj\BagItTools\Exceptions\BagItException
      *   Source file does not exist or the destination is outside the data directory.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues writing to the filesystem.
      */
     public function addFile($source, $dest)
@@ -471,7 +471,7 @@ class Bag
      *
      * @param string $dest
      *   The relative path of the file.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues deleting the file.
      */
     public function removeFile($dest)
@@ -496,7 +496,7 @@ class Bag
      *   The name of the file in the bag.
      * @throws \whikloj\BagItTools\Exceptions\BagItException
      *   Source file does not exist or the destination is outside the data directory.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues creating/deleting temporary file.
      */
     public function createFile($string, $dest)
@@ -891,7 +891,7 @@ class Bag
     /**
      * Wipe the fetch file data
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues deleting files/directories from the filesystem.
      */
     public function clearFetch()
@@ -908,7 +908,7 @@ class Bag
      *
      * @param string $url
      *   The url to delete.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems deleting the file.
      */
     public function removeFetchFile($url)
@@ -1109,7 +1109,7 @@ class Bag
      *
      * @throws \whikloj\BagItTools\Exceptions\BagItException
      *   If the bag cannot be upgraded for some reason.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues writing files to the filesystem.
      */
     public function upgrade()
@@ -1165,7 +1165,7 @@ class Bag
      *
      * @throws \whikloj\BagItTools\Exceptions\BagItException
      *   If the bag root directory already exists.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems writing to the filesystem.
      */
     private function createNewBag()
@@ -1194,7 +1194,7 @@ class Bag
     /**
      * Update a fetch.txt if it exists.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      */
     private function updateFetch()
     {
@@ -1212,7 +1212,7 @@ class Bag
      * @return boolean
      *   Does bag-info.txt exists.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Unable to read bag-info.txt
      */
     private function loadBagInfo()
@@ -1222,7 +1222,7 @@ class Bag
         if (file_exists($fullPath)) {
             $fp = fopen($fullPath, 'rb');
             if ($fp === false) {
-                throw new SystemException("Unable to access {$info_file}");
+                throw new FilesystemException("Unable to access {$info_file}");
             }
             $bagData = [];
             $lineCount = 0;
@@ -1356,7 +1356,7 @@ class Bag
     /**
      * Write the contents of the bag-info array to disk.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues writing the file to disk.
      */
     private function updateBagInfo()
@@ -1364,7 +1364,7 @@ class Bag
         $fullPath = $this->makeAbsolute("bag-info.txt");
         $fp = fopen($fullPath, 'wb');
         if ($fp === false) {
-            throw new SystemException("Could not write bag-info.txt");
+            throw new FilesystemException("Could not write bag-info.txt");
         }
         $this->updateCalculateBagInfoFields();
         $this->updateBagInfoIndex();
@@ -1435,7 +1435,7 @@ class Bag
     /**
      * Remove the bag-info.txt file and data.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Unable to delete the bag-info.txt file.
      */
     private function removeBagInfo()
@@ -1531,7 +1531,7 @@ class Bag
      * @return boolean
      *   Are there any tag manifest files.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems with glob() pattern or loading manifest.
      */
     private function loadTagManifests() : bool
@@ -1570,7 +1570,7 @@ class Bag
     /**
      * Run update against the tag manifests.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues deleting the tag manifest files.
      */
     private function updateTagManifests()
@@ -1593,7 +1593,7 @@ class Bag
     /**
      * Remove all tagmanifest files.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *    Errors with glob() pattern or deleting files from filesystem.
      */
     private function clearTagManifests()
@@ -1608,7 +1608,7 @@ class Bag
      *
      * @param array $exclusions
      *   Hash algorithm names of manifests to preserve.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues deleting files from the filesystem.
      */
     private function removeAllTagManifests($exclusions = [])
@@ -1628,7 +1628,7 @@ class Bag
      *
      * @param string $internal_name
      *   The hash name to remove.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems deleting the tag manifest file.
      */
     private function removeTagManifest($internal_name)
@@ -1644,7 +1644,7 @@ class Bag
     /**
      * Load all payload manifests found on disk.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems with glob() pattern
      * @throws \whikloj\BagItTools\Exceptions\BagItException
      *   Invalid algorithm detected.
@@ -1685,7 +1685,7 @@ class Bag
     /**
      * Run update against the payload manifests.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues deleting payload manifest files.
      */
     private function updatePayloadManifests()
@@ -1707,7 +1707,7 @@ class Bag
     /**
      * Remove all manifest files.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *    Errors with glob() pattern.
      */
     private function clearPayloadManifests()
@@ -1721,7 +1721,7 @@ class Bag
      *
      * @param array $exclusions
      *   Hash algorithm names of manifests to preserve.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues deleting a file.
      */
     private function removeAllPayloadManifests($exclusions = [])
@@ -1739,7 +1739,7 @@ class Bag
      *
      * @param string $internal_name
      *   The hash name to remove.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues deleting the payload manifest file.
      */
     private function removePayloadManifest($internal_name)
@@ -1755,7 +1755,7 @@ class Bag
     /**
      * Load the bagit.txt on disk.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Can't read the file on disk.
      */
     private function loadBagIt()
@@ -1769,7 +1769,7 @@ class Bag
         } else {
             $contents = file_get_contents($fullPath);
             if ($contents === false) {
-                throw new SystemException("Unable to read {$fullPath}");
+                throw new FilesystemException("Unable to read {$fullPath}");
             }
             $lines = explode(PHP_EOL, $contents);
             // remove blank lines.
@@ -1826,7 +1826,7 @@ class Bag
     /**
      * Update the bagit.txt on disk.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues putting contents to the file.
      */
     private function updateBagIt()
@@ -1853,7 +1853,7 @@ class Bag
     /**
      * Load a fetch.txt if it exists.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Unable to read fetch.txt for existing bag.
      */
     private function loadFetch()
@@ -1870,7 +1870,7 @@ class Bag
      *
      * @param  string $filename
      *   The archive filename.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems creating the archive.
      * @throws \whikloj\BagItTools\Exceptions\BagItException
      *   Unable to determine archive format.
@@ -1892,7 +1892,7 @@ class Bag
      *
      * @param  string $filename
      *   The archive filename.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems creating the archive.
      */
     private function makeZip($filename)
@@ -1908,7 +1908,7 @@ class Bag
             }
             $zip->close();
         } else {
-            throw new SystemException("Unable to create zip file");
+            throw new FilesystemException("Unable to create zip file");
         }
     }
 
@@ -1917,7 +1917,7 @@ class Bag
      *
      * @param  string $filename
      *   The archive filename.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems creating the archive.
      */
     private function makeTar($filename)
@@ -1926,12 +1926,12 @@ class Bag
         $compression = self::extensionTarCompression($extension);
         $tar = new \Archive_Tar($filename, $compression);
         if ($tar === false) {
-            throw new SystemException("Error creating Tar file.");
+            throw new FilesystemException("Error creating Tar file.");
         }
         $parent = $this->getParentDir();
         $files = BagUtils::getAllFiles($this->bagRoot);
         if (!$tar->createModify($files, "", $parent)) {
-            throw new SystemException("Error adding files to {$filename}.");
+            throw new FilesystemException("Error adding files to {$filename}.");
         }
     }
 
@@ -1954,7 +1954,7 @@ class Bag
      *   The full path to the archive file.
      * @return string
      *   The full path to extracted bag.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems accessing and/or uncompressing files on filesystem.
      * @throws \whikloj\BagItTools\Exceptions\BagItException
      *   Unable to determine correct archive format or file does not exist.
@@ -1983,7 +1983,7 @@ class Bag
      *   The full path to the zip file.
      * @return string
      *   The path the archive file was extracted to.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems extracting the zip file.
      */
     private static function unzipBag($filename) : string
@@ -1991,7 +1991,7 @@ class Bag
         $zip = new \ZipArchive;
         $res = $zip->open($filename);
         if ($res === false) {
-            throw new SystemException("Unable to unzip {$filename}");
+            throw new FilesystemException("Unable to unzip {$filename}");
         }
         $directory = self::extractDir();
         $zip->extractTo($directory);
@@ -2008,7 +2008,7 @@ class Bag
      *   The extension pulled from the filename.
      * @return string
      *   The path the archive file was extracted to.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems extracting the zip file.
      */
     private static function untarBag($filename, $extension) : string
@@ -2018,7 +2018,7 @@ class Bag
         $tar = new \Archive_Tar($filename, $compression);
         $res = $tar->extract($directory);
         if ($res === false) {
-            throw new SystemException("Usable to untar {$filename}");
+            throw new FilesystemException("Usable to untar {$filename}");
         }
         return $directory;
     }
@@ -2042,7 +2042,7 @@ class Bag
      *
      * @return string
      *   The path to a new temporary directory.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues creating/deleting files on filesystem.
      */
     private static function extractDir() : string
@@ -2125,7 +2125,7 @@ class Bag
      *
      * @param  string $filePattern
      *   The file pattern.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems matching or deleting files.
      */
     private function clearFilesOfPattern($filePattern)

--- a/src/BagUtils.php
+++ b/src/BagUtils.php
@@ -3,7 +3,7 @@
 namespace whikloj\BagItTools;
 
 use whikloj\BagItTools\Exceptions\BagItException;
-use whikloj\BagItTools\Exceptions\SystemException;
+use whikloj\BagItTools\Exceptions\FilesystemException;
 
 /**
  * Utility class to hold static functions.
@@ -93,14 +93,14 @@ class BagUtils
      * @return array
      *   Array of matches.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Error in matching pattern.
      */
     public static function findAllByPattern($pattern) : array
     {
         $matches=glob($pattern);
         if ($matches === false) {
-            throw new SystemException("Error matching pattern {$pattern}");
+            throw new FilesystemException("Error matching pattern {$pattern}");
         }
         return $matches;
     }
@@ -227,14 +227,14 @@ class BagUtils
      *   The source path.
      * @param string $destFile
      *   The destination path.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   If the copy() call fails.
      * @see \copy()
      */
     public static function checkedCopy($sourceFile, $destFile)
     {
         if (!@copy($sourceFile, $destFile)) {
-            throw new SystemException("Unable to copy file ({$sourceFile}) to ({$destFile})");
+            throw new FilesystemException("Unable to copy file ({$sourceFile}) to ({$destFile})");
         }
     }
 
@@ -247,14 +247,14 @@ class BagUtils
      *   The permissions on the new directories.
      * @param bool $recursive
      *   Whether to create intermediate directories automatically.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   If the mkdir() call fails.
      * @see \mkdir()
      */
     public static function checkedMkdir($path, $mode = 0777, $recursive = false)
     {
         if (!@mkdir($path, $mode, $recursive)) {
-            throw new SystemException("Unable to create directory {$path}");
+            throw new FilesystemException("Unable to create directory {$path}");
         }
     }
 
@@ -269,7 +269,7 @@ class BagUtils
      *   Flags to pass on to file_put_contents.
      * @return int
      *   Number of bytes written to the file.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   On any error putting the contents to the file.
      * @see \file_put_contents()
      */
@@ -277,7 +277,7 @@ class BagUtils
     {
         $res = @file_put_contents($path, $contents, $flags);
         if ($res === false) {
-            throw new SystemException("Unable to put contents to file {$path}");
+            throw new FilesystemException("Unable to put contents to file {$path}");
         }
         return $res;
     }
@@ -287,14 +287,14 @@ class BagUtils
      *
      * @param string $path
      *   The path to remove.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   If the call to unlink() fails.
      * @see \unlink()
      */
     public static function checkedUnlink($path)
     {
         if (!@unlink($path)) {
-            throw new SystemException("Unable to delete path {$path}");
+            throw new FilesystemException("Unable to delete path {$path}");
         }
     }
 
@@ -307,7 +307,7 @@ class BagUtils
      *   The prefix to the file.
      * @return string
      *   The path to the temporary filename.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues creating the file.
      * @see \tempnam()
      */
@@ -315,7 +315,7 @@ class BagUtils
     {
         $res = @tempnam($directory, $prefix);
         if ($res === false) {
-            throw new SystemException("Unable to create a temporary file with directory ${directory}, prefix" .
+            throw new FilesystemException("Unable to create a temporary file with directory ${directory}, prefix" .
             " {$prefix}");
         }
         return $res;
@@ -328,14 +328,14 @@ class BagUtils
      *   The file pointer.
      * @param string $content
      *   The content to write.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problem writing to file.
      */
     public static function checkedFwrite($fp, $content)
     {
         $res = @fwrite($fp, $content);
         if ($res === false) {
-            throw new SystemException("Error writing to file");
+            throw new FilesystemException("Error writing to file");
         }
     }
 }

--- a/src/BagUtils.php
+++ b/src/BagUtils.php
@@ -2,6 +2,9 @@
 
 namespace whikloj\BagItTools;
 
+use whikloj\BagItTools\Exceptions\BagItException;
+use whikloj\BagItTools\Exceptions\SystemException;
+
 /**
  * Utility class to hold static functions.
  *
@@ -90,14 +93,14 @@ class BagUtils
      * @return array
      *   Array of matches.
      *
-     * @throws \whikloj\BagItTools\BagItException
+     * @throws \whikloj\BagItTools\Exceptions\SystemException
      *   Error in matching pattern.
      */
     public static function findAllByPattern($pattern) : array
     {
         $matches=glob($pattern);
         if ($matches === false) {
-            throw new BagItException("Error matching pattern {$pattern}");
+            throw new SystemException("Error matching pattern {$pattern}");
         }
         return $matches;
     }
@@ -215,5 +218,124 @@ class BagUtils
             }
         }
         return $found_files;
+    }
+
+    /**
+     * Copy a file and check that the copy succeeded.
+     *
+     * @param string $sourceFile
+     *   The source path.
+     * @param string $destFile
+     *   The destination path.
+     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     *   If the copy() call fails.
+     * @see \copy()
+     */
+    public static function checkedCopy($sourceFile, $destFile)
+    {
+        if (!@copy($sourceFile, $destFile)) {
+            throw new SystemException("Unable to copy file ({$sourceFile}) to ({$destFile})");
+        }
+    }
+
+    /**
+     * Make a directory (or directories) and check it succeeds.
+     *
+     * @param string $path
+     *   The path to create.
+     * @param int $mode
+     *   The permissions on the new directories.
+     * @param bool $recursive
+     *   Whether to create intermediate directories automatically.
+     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     *   If the mkdir() call fails.
+     * @see \mkdir()
+     */
+    public static function checkedMkdir($path, $mode = 0777, $recursive = false)
+    {
+        if (!@mkdir($path, $mode, $recursive)) {
+            throw new SystemException("Unable to create directory {$path}");
+        }
+    }
+
+    /**
+     * Put contents to a file and check it succeeded.
+     *
+     * @param string $path
+     *   The path of the file.
+     * @param mixed $contents
+     *   The contents to put
+     * @param int $flags
+     *   Flags to pass on to file_put_contents.
+     * @return int
+     *   Number of bytes written to the file.
+     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     *   On any error putting the contents to the file.
+     * @see \file_put_contents()
+     */
+    public static function checkedFilePut($path, $contents, $flags = 0)
+    {
+        $res = @file_put_contents($path, $contents, $flags);
+        if ($res === false) {
+            throw new SystemException("Unable to put contents to file {$path}");
+        }
+        return $res;
+    }
+
+    /**
+     * Delete a file/directory and check it succeeded.
+     *
+     * @param string $path
+     *   The path to remove.
+     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     *   If the call to unlink() fails.
+     * @see \unlink()
+     */
+    public static function checkedUnlink($path)
+    {
+        if (!@unlink($path)) {
+            throw new SystemException("Unable to delete path {$path}");
+        }
+    }
+
+    /**
+     * Create a temporary file and check it succeeded.
+     *
+     * @param string $directory
+     *   The directory to create the file in.
+     * @param string $prefix
+     *   The prefix to the file.
+     * @return string
+     *   The path to the temporary filename.
+     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     *   Issues creating the file.
+     * @see \tempnam()
+     */
+    public static function checkedTempnam($directory = "", $prefix = "") : string
+    {
+        $res = @tempnam($directory, $prefix);
+        if ($res === false) {
+            throw new SystemException("Unable to create a temporary file with directory ${directory}, prefix" .
+            " {$prefix}");
+        }
+        return $res;
+    }
+
+    /**
+     * Write to a file resource and check it succeeded.
+     *
+     * @param Resource $fp
+     *   The file pointer.
+     * @param string $content
+     *   The content to write.
+     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     *   Problem writing to file.
+     */
+    public static function checkedFwrite($fp, $content)
+    {
+        $res = @fwrite($fp, $content);
+        if ($res === false) {
+            throw new SystemException("Error writing to file");
+        }
     }
 }

--- a/src/Exceptions/BagItException.php
+++ b/src/Exceptions/BagItException.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace whikloj\BagItTools;
+namespace whikloj\BagItTools\Exceptions;
 
 /**
  * BagIt exception thrown for all errors or client invalidation.
  *
- * @package whikloj\BagItTools
+ * @package whikloj\BagItTools\Exceptions
  * @author whikloj
  * @since 1.0.0
  */

--- a/src/Exceptions/FilesystemException.php
+++ b/src/Exceptions/FilesystemException.php
@@ -9,7 +9,7 @@ namespace whikloj\BagItTools\Exceptions;
  * @author whikloj
  * @since 2.1.0
  */
-class SystemException extends BagItException
+class FilesystemException extends BagItException
 {
 
 }

--- a/src/Exceptions/SystemException.php
+++ b/src/Exceptions/SystemException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace whikloj\BagItTools\Exceptions;
+
+/**
+ * Errors related to operations on the filesystem.
+ *
+ * @package whikloj\BagItTools\Exceptions
+ * @author whikloj
+ * @since 2.1.0
+ */
+class SystemException extends BagItException
+{
+
+}

--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -3,7 +3,7 @@
 namespace whikloj\BagItTools;
 
 use whikloj\BagItTools\Exceptions\BagItException;
-use whikloj\BagItTools\Exceptions\SystemException;
+use whikloj\BagItTools\Exceptions\FilesystemException;
 
 /**
  * Class for holding and interacting with fetch.txt data.
@@ -79,7 +79,7 @@ class Fetch
      *   The bag this fetch is part of.
      * @param bool $load
      *   Whether to load a fetch.txt
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Unable to read fetch.txt for existing bag.
      */
     public function __construct(Bag $bag, $load = false)
@@ -201,7 +201,7 @@ class Fetch
      *
      * @param string $url
      *   The url to remove.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues removing the file from the filesystem.
      */
     public function removeFile($url)
@@ -225,7 +225,7 @@ class Fetch
     /**
      * Update the fetch.txt on disk with the fetch file records.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   If we can't write to disk.
      */
     public function update()
@@ -237,7 +237,7 @@ class Fetch
      * Remove any downloaded files referenced in fetch.txt. This is called before we package up the Bag or finalize the
      * directory.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems removing file from filesystem.
      */
     public function cleanup()
@@ -255,7 +255,7 @@ class Fetch
     /**
      * Clean up any downloaded files and then wipe the internal data array.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Problems removing file from filesystem.
      */
     public function clearData()
@@ -299,7 +299,7 @@ class Fetch
     /**
      * Load an existing fetch.txt
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Unable to read the fetch.txt file.
      */
     private function loadFiles()
@@ -308,7 +308,7 @@ class Fetch
         if (file_exists($this->filename)) {
             $fp = fopen($this->filename, "rb");
             if ($fp === false) {
-                throw new SystemException("Unable to read file {$this->filename}");
+                throw new FilesystemException("Unable to read file {$this->filename}");
             }
             $lineCount = 0;
             while (!feof($fp)) {
@@ -346,7 +346,7 @@ class Fetch
      *   The content from curl.
      * @param string $destination
      *   The relative path to the final file.
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Trouble writing to disk.
      */
     private function saveFileData($content, $destination)
@@ -449,7 +449,7 @@ class Fetch
     /**
      * Download files using Curl.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Unable to open a file handle to download to.
      */
     private function downloadFiles()
@@ -499,7 +499,7 @@ class Fetch
     /**
      * Utility to recreate the fetch file using the currently stored files.
      *
-     * @throws \whikloj\BagItTools\Exceptions\SystemException
+     * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   If we can't write the fetch file.
      */
     private function writeToDisk()
@@ -510,7 +510,7 @@ class Fetch
         if (count($this->files) > 0) {
             $fp = fopen($this->filename, "wb");
             if ($fp === false) {
-                throw new SystemException("Unable to write {$this->filename}");
+                throw new FilesystemException("Unable to write {$this->filename}");
             }
             foreach ($this->files as $fileData) {
                 $line = "{$fileData['uri']} {$fileData['size']} {$fileData['destination']}" . PHP_EOL;

--- a/tests/BagInternalTest.php
+++ b/tests/BagInternalTest.php
@@ -16,7 +16,6 @@ class BagInternalTest extends BagItTestFramework
    * @group BagInternal
    * @covers \whikloj\BagItTools\Bag::makeRelative
    * @throws \ReflectionException
-   * @throws \whikloj\BagItTools\BagItException
    */
     public function testMakeRelativePlain()
     {
@@ -57,7 +56,6 @@ class BagInternalTest extends BagItTestFramework
    * @group BagInternal
    * @covers \whikloj\BagItTools\Bag::pathInBagData
    * @throws \ReflectionException
-   * @throws \whikloj\BagItTools\BagItException
    */
     public function testPathInBagData()
     {
@@ -95,7 +93,6 @@ class BagInternalTest extends BagItTestFramework
      * @covers \whikloj\BagItTools\Bag::wrapBagInfoText
      * @covers \whikloj\BagItTools\Bag::wrapAtLength
      * @throws \ReflectionException
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testWrapBagInfo()
     {
@@ -133,7 +130,6 @@ class BagInternalTest extends BagItTestFramework
      * @group Internal
      * @covers \whikloj\BagItTools\Bag::compareVersion
      * @throws \ReflectionException
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testVersionCompare()
     {

--- a/tests/BagItTestFramework.php
+++ b/tests/BagItTestFramework.php
@@ -98,8 +98,11 @@ class BagItTestFramework extends TestCase
     protected function getTempName()
     {
         $tempname = tempnam("", "bagit_");
-        unlink($tempname);
-        return $tempname;
+        if ($tempname !== false) {
+            if (unlink($tempname)) {
+                return $tempname;
+            }
+        }
     }
 
     /**

--- a/tests/BagTest.php
+++ b/tests/BagTest.php
@@ -18,8 +18,7 @@ class BagTest extends BagItTestFramework
    * @covers ::__construct
    * @covers ::createNewBag
    * @covers ::updateBagIt
-   * @throws \whikloj\BagItTools\BagItException
-   */
+      */
     public function testConstructNewBag()
     {
         $this->assertFileNotExists($this->tmpdir);
@@ -44,8 +43,7 @@ class BagTest extends BagItTestFramework
    * @covers \whikloj\BagItTools\AbstractManifest::loadFile
    * @covers \whikloj\BagItTools\AbstractManifest::cleanUpRelPath
    * @covers \whikloj\BagItTools\AbstractManifest::addToNormalizedList
-   * @throws \whikloj\BagItTools\BagItException
-   */
+      */
     public function testOpenBag()
     {
         $this->tmpdir = $this->prepareBasicTestBag();
@@ -62,7 +60,6 @@ class BagTest extends BagItTestFramework
      * Test the getVersion function.
      * @group Bag
      * @covers ::getVersion
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testGetVersion()
     {
@@ -87,7 +84,6 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::getDataDirectory
      * @covers ::getBagRoot
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testBagDirs()
     {
@@ -101,8 +97,7 @@ class BagTest extends BagItTestFramework
    * Test adding a file to a bag.
    * @group Bag
    * @covers ::addFile
-   * @throws \whikloj\BagItTools\BagItException
-   */
+      */
     public function testAddFile()
     {
         $source_file = self::TEST_IMAGE['filename'];
@@ -118,7 +113,7 @@ class BagTest extends BagItTestFramework
    * Test adding a file that doesn't exist.
    * @group Bag
    * @covers ::addFile
-   * @expectedException \whikloj\BagItTools\BagItException
+   * @expectedException \whikloj\BagItTools\Exceptions\BagItException
    */
     public function testAddFileNoSource()
     {
@@ -131,7 +126,7 @@ class BagTest extends BagItTestFramework
    * Test adding a file with an invalid destination directory.
    * @group Bag
    * @covers ::addFile
-   * @expectedException \whikloj\BagItTools\BagItException
+   * @expectedException \whikloj\BagItTools\Exceptions\BagItException
    */
     public function testAddFileInvalidDestination()
     {
@@ -144,7 +139,7 @@ class BagTest extends BagItTestFramework
      * Test adding a file to a bag twice.
      * @group Bag
      * @covers ::addFile
-     * @expectedException  \whikloj\BagItTools\BagItException
+     * @expectedException  \whikloj\BagItTools\Exceptions\BagItException
      */
     public function testAddFileTwice()
     {
@@ -162,7 +157,6 @@ class BagTest extends BagItTestFramework
      * Test removing a file from a bag.
      * @group Bag
      * @covers ::removeFile
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testRemoveFile()
     {
@@ -178,7 +172,6 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::addFile
      * @covers ::createFile
-     * @throws  \whikloj\BagItTools\BagItException
      */
     public function testCreateFile()
     {
@@ -203,7 +196,7 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::addFile
      * @covers ::createFile
-     * @expectedException  \whikloj\BagItTools\BagItException
+     * @expectedException  \whikloj\BagItTools\Exceptions\BagItException
      */
     public function testCreateFileTwice()
     {
@@ -222,7 +215,6 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::removeFile
      * @covers ::checkForEmptyDir
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testRemoveEmptyDirectories()
     {
@@ -260,7 +252,6 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::removeFile
      * @covers ::checkForEmptyDir
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testKeepDirectoryWithHiddenFile()
     {
@@ -289,7 +280,6 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::update
      * @covers \whikloj\BagItTools\AbstractManifest::getHashes
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testUpdateOnDisk()
     {
@@ -330,7 +320,6 @@ class BagTest extends BagItTestFramework
      * @covers ::setFileEncoding
      * @covers ::getFileEncoding
      * @covers \whikloj\BagItTools\BagUtils::getValidCharset
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testSetFileEncodingSuccess()
     {
@@ -359,7 +348,7 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::setFileEncoding
      * @covers \whikloj\BagItTools\BagUtils::getValidCharset
-     * @expectedException \whikloj\BagItTools\BagItException
+     * @expectedException \whikloj\BagItTools\Exceptions\BagItException
      */
     public function testSetFileEncodingFailure()
     {
@@ -382,7 +371,6 @@ class BagTest extends BagItTestFramework
      * @covers ::addAlgorithm
      * @covers ::removeAlgorithm
      * @covers ::getAlgorithms
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testGetHashesNames()
     {
@@ -412,7 +400,6 @@ class BagTest extends BagItTestFramework
      * @covers ::getAlgorithms
      * @covers ::hasAlgorithm
      * @covers ::hasHash
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testGetHashesCommon()
     {
@@ -450,7 +437,7 @@ class BagTest extends BagItTestFramework
      *
      * @group Bag
      * @covers ::removeAlgorithm
-     * @expectedException \whikloj\BagItTools\BagItException
+     * @expectedException \whikloj\BagItTools\Exceptions\BagItException
      */
     public function testRemoveLastHash()
     {
@@ -464,7 +451,6 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::algorithmIsSupported
      * @covers ::hashIsSupported
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testIsSupportedHash()
     {
@@ -479,7 +465,6 @@ class BagTest extends BagItTestFramework
      * @covers ::setAlgorithm
      * @covers ::removeAllPayloadManifests
      * @covers ::removePayloadManifest
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testSetAlgorithm()
     {
@@ -496,7 +481,7 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::addFile
      * @covers ::reservedFilename
-     * @expectedException  \whikloj\BagItTools\BagItException
+     * @expectedException  \whikloj\BagItTools\Exceptions\BagItException
      */
     public function testUseReservedFilename()
     {
@@ -509,7 +494,7 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::create
      * @covers ::addFile
-     * @expectedException \whikloj\BagItTools\BagItException
+     * @expectedException \whikloj\BagItTools\Exceptions\BagItException
      *
      *
      * Need to review, we currently rebase things NOT in data/ into data/
@@ -527,7 +512,6 @@ class BagTest extends BagItTestFramework
      * @covers ::validate
      * @covers \whikloj\BagItTools\AbstractManifest::loadFile
      * @covers \whikloj\BagItTools\AbstractManifest::validate
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testWarningOnMd5()
     {
@@ -548,7 +532,7 @@ class BagTest extends BagItTestFramework
      * @covers ::load
      * @covers ::getExtensions
      * @covers ::isCompressed
-     * @expectedException  \whikloj\BagItTools\BagItException
+     * @expectedException  \whikloj\BagItTools\Exceptions\BagItException
      */
     public function testNonExistantCompressed()
     {
@@ -564,7 +548,6 @@ class BagTest extends BagItTestFramework
      * @covers ::uncompressBag
      * @covers ::getExtensions
      * @covers ::untarBag
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testUncompressTarGz()
     {
@@ -589,7 +572,6 @@ class BagTest extends BagItTestFramework
      * @covers ::uncompressBag
      * @covers ::getExtensions
      * @covers ::untarBag
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testUncompressTarBzip()
     {
@@ -613,7 +595,6 @@ class BagTest extends BagItTestFramework
      * @covers ::uncompressBag
      * @covers ::getExtensions
      * @covers ::unzipBag
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testUncompressZip()
     {
@@ -638,7 +619,6 @@ class BagTest extends BagItTestFramework
      * @covers ::package
      * @covers ::makePackage
      * @covers ::makeZip
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testZipBag()
     {
@@ -667,7 +647,6 @@ class BagTest extends BagItTestFramework
      * @covers ::package
      * @covers ::makePackage
      * @covers ::makeTar
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testTarBag()
     {
@@ -696,7 +675,6 @@ class BagTest extends BagItTestFramework
      * @covers ::package
      * @covers ::makePackage
      * @covers ::makeTar
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testTarGzBag()
     {
@@ -725,7 +703,6 @@ class BagTest extends BagItTestFramework
      * @covers ::package
      * @covers ::makePackage
      * @covers ::makeTar
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testTarBzipBag()
     {
@@ -751,7 +728,6 @@ class BagTest extends BagItTestFramework
      * @group Bag
      * @covers ::upgrade()
      * @covers ::getVersionString
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testUpdateV07()
     {
@@ -795,7 +771,7 @@ class BagTest extends BagItTestFramework
      *
      * @group Bag
      * @covers ::upgrade
-     * @expectedException \whikloj\BagItTools\BagItException
+     * @expectedException \whikloj\BagItTools\Exceptions\BagItException
      */
     public function testUpgradeCreatedBag()
     {
@@ -808,7 +784,7 @@ class BagTest extends BagItTestFramework
      *
      * @group Bag
      * @covers ::upgrade
-     * @expectedException \whikloj\BagItTools\BagItException
+     * @expectedException \whikloj\BagItTools\Exceptions\BagItException
      */
     public function testUpgradeV1Bag()
     {
@@ -823,7 +799,7 @@ class BagTest extends BagItTestFramework
      *
      * @group Bag
      * @covers ::upgrade
-     * @expectedException \whikloj\BagItTools\BagItException
+     * @expectedException \whikloj\BagItTools\Exceptions\BagItException
      */
     public function testUpgradeInvalid()
     {

--- a/tests/BagUtilsTest.php
+++ b/tests/BagUtilsTest.php
@@ -37,7 +37,6 @@ class BagUtilsTest extends BagItTestFramework
 
     /**
      * @covers ::findAllByPattern
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testFindAllByPattern()
     {
@@ -106,5 +105,76 @@ class BagUtilsTest extends BagItTestFramework
 
         $files = BagUtils::getAllFiles(self::TEST_EXTENDED_BAG_DIR, ['data', 'alt_tags']);
         $this->assertCount(4, $files);
+    }
+
+    /**
+     * @covers ::checkedUnlink
+     * @expectedException \whikloj\BagItTools\Exceptions\SystemException
+     */
+    public function testCheckedUnlink()
+    {
+        // try to delete a non-existant file.
+        BagUtils::checkedUnlink($this->tmpdir);
+    }
+
+    /**
+     * @covers ::checkedMkdir
+     * @expectedException  \whikloj\BagItTools\Exceptions\SystemException
+     */
+    public function testCheckedMkdir()
+    {
+        // Create a directory
+        touch($this->tmpdir);
+        // Try to create a directory with the same name.
+        BagUtils::checkedMkdir($this->tmpdir);
+    }
+
+    /**
+     * @covers ::checkedCopy
+     * @expectedException  \whikloj\BagItTools\Exceptions\SystemException
+     */
+    public function testCheckedCopyNoSource()
+    {
+        $destFile = $this->getTempName();
+        // Source file does not exist.
+        BagUtils::checkedCopy($this->tmpdir, $destFile);
+    }
+
+    /**
+     * @covers ::checkedCopy
+     * @expectedException  \whikloj\BagItTools\Exceptions\SystemException
+     */
+    public function testCheckedCopyNoDest()
+    {
+        // Real source file
+        $sourceFile = self::TEST_IMAGE['filename'];
+        // Directory of destination does not exist.
+        BagUtils::checkedCopy($sourceFile, $this->tmpdir . DIRECTORY_SEPARATOR . "someotherfile");
+    }
+
+    /**
+     * @covers ::checkedFilePut
+     * @expectedException \whikloj\BagItTools\Exceptions\SystemException
+     */
+    public function testCheckedFilePut()
+    {
+        BagUtils::checkedFilePut($this->tmpdir . DIRECTORY_SEPARATOR . "someotherfile", "some content");
+    }
+
+    /**
+     * @covers ::checkedFwrite
+     * @expectedException  \whikloj\BagItTools\Exceptions\SystemException
+     */
+    public function testCheckedFwrite()
+    {
+        // Open a pointer to a new file.
+        $fp = fopen($this->tmpdir, "w+");
+        if ($fp === false) {
+            throw new \Exception("Couldn't open file ({$this->tmpdir}).");
+        }
+        // Close the file pointer.
+        fclose($fp);
+        // Write to the file.
+        BagUtils::checkedFwrite($fp, "Some example text");
     }
 }

--- a/tests/BagUtilsTest.php
+++ b/tests/BagUtilsTest.php
@@ -109,7 +109,7 @@ class BagUtilsTest extends BagItTestFramework
 
     /**
      * @covers ::checkedUnlink
-     * @expectedException \whikloj\BagItTools\Exceptions\SystemException
+     * @expectedException \whikloj\BagItTools\Exceptions\FilesystemException
      */
     public function testCheckedUnlink()
     {
@@ -119,7 +119,7 @@ class BagUtilsTest extends BagItTestFramework
 
     /**
      * @covers ::checkedMkdir
-     * @expectedException  \whikloj\BagItTools\Exceptions\SystemException
+     * @expectedException  \whikloj\BagItTools\Exceptions\FilesystemException
      */
     public function testCheckedMkdir()
     {
@@ -131,7 +131,7 @@ class BagUtilsTest extends BagItTestFramework
 
     /**
      * @covers ::checkedCopy
-     * @expectedException  \whikloj\BagItTools\Exceptions\SystemException
+     * @expectedException  \whikloj\BagItTools\Exceptions\FilesystemException
      */
     public function testCheckedCopyNoSource()
     {
@@ -142,7 +142,7 @@ class BagUtilsTest extends BagItTestFramework
 
     /**
      * @covers ::checkedCopy
-     * @expectedException  \whikloj\BagItTools\Exceptions\SystemException
+     * @expectedException  \whikloj\BagItTools\Exceptions\FilesystemException
      */
     public function testCheckedCopyNoDest()
     {
@@ -154,7 +154,7 @@ class BagUtilsTest extends BagItTestFramework
 
     /**
      * @covers ::checkedFilePut
-     * @expectedException \whikloj\BagItTools\Exceptions\SystemException
+     * @expectedException \whikloj\BagItTools\Exceptions\FilesystemException
      */
     public function testCheckedFilePut()
     {
@@ -163,7 +163,7 @@ class BagUtilsTest extends BagItTestFramework
 
     /**
      * @covers ::checkedFwrite
-     * @expectedException  \whikloj\BagItTools\Exceptions\SystemException
+     * @expectedException  \whikloj\BagItTools\Exceptions\FilesystemException
      */
     public function testCheckedFwrite()
     {

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -108,4 +108,21 @@ class CommandTest extends BagItTestFramework
         $this->assertContains("[WARNING] This manifest is MD5, you should use setAlgorithm('sha512') to " .
             "upgrade. -- file: manifest-md5.txt", $output);
     }
+
+    /**
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function testRelativeDirectoryToNoBag()
+    {
+        $this->commandTester->execute([
+            'bag-path' => "subdirectory/to/bag",
+        ], [
+            'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+        ]);
+        $output = $this->commandTester->getDisplay();
+        // Split this in two as we don't know what the actual root directory with be
+        $this->assertContains("[ERROR] Path", $output);
+        $this->assertContains("/subdirectory/to/bag does not exist, cannot validate.", $output);
+    }
 }

--- a/tests/ExtendedBagTest.php
+++ b/tests/ExtendedBagTest.php
@@ -19,7 +19,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers \whikloj\BagItTools\AbstractManifest::getErrors
      * @covers ::getWarnings
      * @covers \whikloj\BagItTools\AbstractManifest::getWarnings
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testValidateExtendedBag()
     {
@@ -37,7 +36,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers \whikloj\BagItTools\TagManifest::update
      * @covers \whikloj\BagItTools\AbstractManifest::update
      * @covers \whikloj\BagItTools\AbstractManifest::writeToDisk
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testNoTagManifest()
     {
@@ -74,7 +72,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers ::updateCalculateBagInfoFields
      * @covers ::update
      * @covers \whikloj\BagItTools\AbstractManifest::loadFile
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testLoadExtendedBag()
     {
@@ -115,7 +112,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers ::hasBagInfoTag
      * @covers ::getBagInfoByTag
      * @covers ::bagInfoTagExists
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testGetBagInfoByKey()
     {
@@ -139,7 +135,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers ::getBagInfoByTag
      * @covers ::removeBagInfoTag
      * @covers ::bagInfoTagExists
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testRemoveBagInfoByTag()
     {
@@ -161,7 +156,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers ::getBagInfoByTag
      * @covers ::removeBagInfoTagIndex
      * @covers ::bagInfoTagExists
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testRemoveBagInfoByTagIndex()
     {
@@ -200,7 +194,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers ::updateTagManifests
      * @covers ::updatePayloadManifests
      * @covers ::ensureTagManifests
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testGetHashesCommon()
     {
@@ -349,7 +342,7 @@ class ExtendedBagTest extends BagItTestFramework
      * @group Extended
      * @covers ::addBagInfoTag
      * @covers ::setExtended
-     * @expectedException  \whikloj\BagItTools\BagItException
+     * @expectedException  \whikloj\BagItTools\Exceptions\BagItException
      */
     public function testSetGeneratedField()
     {
@@ -367,7 +360,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @group Extended
      * @covers ::loadBagInfo
      * @covers ::compareVersion
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testInvalidBagInfov1()
     {
@@ -384,7 +376,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @group Extended
      * @covers ::loadBagInfo
      * @covers ::compareVersion
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testInvalidBagInfov097()
     {
@@ -406,7 +397,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers ::load
      * @covers ::getPayloadManifests
      * @covers ::getTagManifests
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testGetManifests()
     {
@@ -425,7 +415,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers ::load
      * @covers ::getPayloadManifests
      * @covers ::getTagManifests
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testGetManifestsExtended()
     {
@@ -446,7 +435,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers ::calculateTotalFileSizeAndAmountOfFiles
      * @covers ::getBagInfoByTag
      * @covers ::update
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testOxumCalculationForManyHashAlogrithm()
     {
@@ -469,7 +457,6 @@ class ExtendedBagTest extends BagItTestFramework
      * @covers ::convertToHumanReadable
      * @covers ::getBagInfoByTag
      * @covers ::update
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testCalculatedBagSize()
     {

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -19,7 +19,6 @@ class ManifestTest extends BagItTestFramework
    * @covers \whikloj\BagItTools\PayloadManifest::__construct
    * @covers ::getFilename
    * @covers ::getAlgorithm
-   * @throws \whikloj\BagItTools\BagItException
    */
     public function testCreateManifest()
     {
@@ -40,7 +39,6 @@ class ManifestTest extends BagItTestFramework
      * @covers ::update
      * @covers \whikloj\BagItTools\TagManifest::update
      * @covers \whikloj\BagItTools\PayloadManifest::update
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testCheckManifests()
     {
@@ -96,7 +94,6 @@ class ManifestTest extends BagItTestFramework
      * @covers ::addToNormalizedList
      * @covers \whikloj\BagItTools\TagManifest::validate
      * @covers \whikloj\BagItTools\PayloadManifest::validate
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testValidateManifests()
     {
@@ -114,7 +111,6 @@ class ManifestTest extends BagItTestFramework
      * @covers ::loadFile
      * @covers ::addLoadWarning
      * @covers ::normalizePath
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testRelativeManifestPaths()
     {
@@ -131,7 +127,6 @@ class ManifestTest extends BagItTestFramework
      * @covers ::loadFile
      * @covers ::addLoadError
      * @covers ::normalizePath
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testDuplicateManifestPaths()
     {
@@ -148,7 +143,6 @@ class ManifestTest extends BagItTestFramework
      * @covers ::loadFile
      * @covers ::addLoadWarning
      * @covers ::normalizePath
-     * @throws \whikloj\BagItTools\BagItException
      */
     public function testDuplicateCaseInsensitiveManifestPaths()
     {


### PR DESCRIPTION
Resolves #19 

This PR adds a new exception `FilesystemException` which is related to errors with filesystem operations. It is a sub-class of the existing `BagItException` so it should not require changes to existing exception handling.

