### PR TITLE
Ensure special characters in manifest filepaths are urlencoded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,21 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.host-os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["7.3", "7.4"]
+        php-versions: ["7.4", "8.0"]
         experimental: [false]
+        host-os: ["ubuntu-latest"]
         include:
-          - php-versions: "8.0"
+          - php-versions: "7.3"
+            experimental: false
+            host-os: "ubuntu-18.04"
+          - php-versions: "8.1"
             experimental: true
+            host-os: "ubuntu-latest"
 
     name: PHP ${{ matrix.php-versions }}
     steps:
@@ -30,7 +35,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit
+          coverage: none
 
       - name: Get composer cache directory
         id: composercache

--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,8 @@
       "@check",
       "phpdbg -qrr ./vendor/bin/phpunit"
     ]
+  },
+  "config": {
+    "allow-plugins": {}
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,8 @@
     ]
   },
   "config": {
-    "allow-plugins": {}
+    "allow-plugins": {
+      "symfony/flex": false
+    }
   }
 }

--- a/src/Bag.php
+++ b/src/Bag.php
@@ -866,18 +866,10 @@ class Bag
      */
     public function addFetchFile($url, $destination, $size = null)
     {
-        $fetchData = [
-            'uri' => $url,
-            'destination' => $destination,
-        ];
-        if (!is_null($size) && is_int($size)) {
-            $fetchData['size'] = $size;
-        }
         if (!isset($this->fetchFile)) {
             $this->fetchFile = new Fetch($this, false);
         }
-        // Download the file now to help with manifest handling, deleted when you package() or finalize().
-        $this->fetchFile->download($fetchData);
+        $this->fetchFile->addFile($url, $destination, $size);
         $this->changed = true;
     }
 

--- a/src/BagUtils.php
+++ b/src/BagUtils.php
@@ -353,4 +353,66 @@ class BagUtils
             throw new FilesystemException("Error writing to file");
         }
     }
+
+    /**
+     * Decode a file path according to the special rules of the spec.
+     *
+     * RFC 8943 - sections 2.1.3 & 2.2.3
+     * If _filename_ includes an LF, a CR, a CRLF, or a percent sign (%), those characters (and only those) MUST be
+     * percent-encoded as described in [RFC3986].
+     *
+     * @param string $line
+     *   The original filepath from the manifest file.
+     * @return string
+     *   The filepath with the special characters decoded.
+     */
+    public static function decodeFilepath(string $line): string
+    {
+        // Strip newlines from the right.
+        $decoded = rtrim($line, "\r\n");
+        return str_replace(
+            ["%0A", "%0D", "%25"],
+            ["\n", "\r", "%"],
+            $decoded
+        );
+    }
+
+    /**
+     * Encode a file path according to the special rules of the spec.
+     *
+     * RFC 8943 - sections 2.1.3 & 2.2.3
+     * If _filename_ includes an LF, a CR, a CRLF, or a percent sign (%), those characters (and only those) MUST be
+     * percent-encoded as described in [RFC3986].
+     *
+     * @param string $line
+     *   The original file path.
+     * @return string
+     *   The file path with the special manifest characters encoded.
+     */
+    public static function encodeFilepath(string $line): string
+    {
+        // Strip newlines from the right.
+        $encoded = rtrim($line, "\r\n");
+        return str_replace(
+            ["%", "\n", "\r"],
+            ["%25", "%0A", "%0D"],
+            $encoded
+        );
+    }
+
+    /**
+     * Check for unencoded newlines, carriage returns or % symbols in a file path.
+     *
+     * @param string $filepath
+     *   The file path to check
+     * @return bool
+     *   True if there are un-encoded characters
+     * @see \whikloj\BagItTools\BagUtils::encodeFilepath()
+     * @see \whikloj\BagItTools\BagUtils::decodeFilepath()
+     */
+    public static function checkUnencodedFilepath(string $filepath): bool
+    {
+        return (strpos($filepath, "\n") > -1 || strpos($filepath, "\r") > -1 ||
+            preg_match_all("/%(?!(25|0A|0D))/", $filepath));
+    }
 }

--- a/src/BagUtils.php
+++ b/src/BagUtils.php
@@ -412,7 +412,6 @@ class BagUtils
      */
     public static function checkUnencodedFilepath(string $filepath): bool
     {
-        return (strpos($filepath, "\n") > -1 || strpos($filepath, "\r") > -1 ||
-            preg_match_all("/%(?!(25|0A|0D))/", $filepath));
+        return preg_match_all("/%(?!(25|0A|0D))/", $filepath);
     }
 }

--- a/tests/BagInternalTest.php
+++ b/tests/BagInternalTest.php
@@ -282,23 +282,20 @@ class BagInternalTest extends BagItTestFramework
         $loadIssues->setAccessible(true);
         // Initially no errors
         $this->assertCount(0, $loadIssues->getValue($payload)['error']);
-        // unencoded carriage return
-        $methodCall->invokeArgs($payload, ["fail-for-\r-filename.txt", 1]);
-        $this->assertCount(1, $loadIssues->getValue($payload)['error']);
-        // unencoded line feed
-        $methodCall->invokeArgs($payload, ["fail-for-\n-filename.txt", 1]);
-        $this->assertCount(2, $loadIssues->getValue($payload)['error']);
         // unencoded % symbol
         $methodCall->invokeArgs($payload, ["fail-for-%-filename.txt", 1]);
-        $this->assertCount(3, $loadIssues->getValue($payload)['error']);
+        $this->assertCount(1, $loadIssues->getValue($payload)['error']);
+        // Urlencoded character that is not %25, %0A or %0D
+        $methodCall->invokeArgs($payload, ["fail-for-%2F-filename.txt", 1]);
+        $this->assertCount(2, $loadIssues->getValue($payload)['error']);
         // No issue with encoded %
         $methodCall->invokeArgs($payload, ["succeed-for-%25-filename.txt", 1]);
-        $this->assertCount(3, $loadIssues->getValue($payload)['error']);
+        $this->assertCount(2, $loadIssues->getValue($payload)['error']);
         // No issue for encoded line feed
         $methodCall->invokeArgs($payload, ["succeed-for-%0A-filename.txt", 1]);
-        $this->assertCount(3, $loadIssues->getValue($payload)['error']);
+        $this->assertCount(2, $loadIssues->getValue($payload)['error']);
         // No issue for encoded carriage return
         $methodCall->invokeArgs($payload, ["succeed-for-%0D-filename.txt", 1]);
-        $this->assertCount(3, $loadIssues->getValue($payload)['error']);
+        $this->assertCount(2, $loadIssues->getValue($payload)['error']);
     }
 }

--- a/tests/BagUtilsTest.php
+++ b/tests/BagUtilsTest.php
@@ -110,7 +110,7 @@ class BagUtilsTest extends BagItTestFramework
         $this->assertCount(2, $files);
 
         $files = BagUtils::getAllFiles(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'fetchFiles');
-        $this->assertCount(4, $files);
+        $this->assertCount(5, $files);
 
         $files = BagUtils::getAllFiles(self::TEST_EXTENDED_BAG_DIR);
         $this->assertCount(7, $files);
@@ -210,5 +210,20 @@ class BagUtilsTest extends BagItTestFramework
 
         // Write to the file.
         BagUtils::checkedFwrite($fp, "Some example text");
+    }
+
+    /**
+     * @covers ::checkUnencodedFilepath
+     */
+    public function testCheckUnencodedFilepath(): void
+    {
+        $this->assertTrue(BagUtils::checkUnencodedFilepath("some/path/with%2ffake/slashes"));
+        $this->assertTrue(BagUtils::checkUnencodedFilepath("some/path/with%2Ffake/slashes"));
+        $this->assertFalse(BagUtils::checkUnencodedFilepath("some/path/with%252ffake/slashes"));
+        $this->assertFalse(BagUtils::checkUnencodedFilepath("some/path/with%252Ffake/slashes"));
+        $this->assertFalse(BagUtils::checkUnencodedFilepath("some/path/with%0Aencoded/newlines"));
+        $this->assertFalse(BagUtils::checkUnencodedFilepath("some/path/with%0Dencoded/carriage/returns"));
+        $this->assertTrue(BagUtils::checkUnencodedFilepath("some/path/with%22encoded/quotes"));
+        $this->assertFalse(BagUtils::checkUnencodedFilepath("some/path/with/nothing"));
     }
 }

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -120,8 +120,7 @@ class FetchTest extends BagItTestFramework
             self::FETCH_FILES . DIRECTORY_SEPARATOR . $fetchFile,
             $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'fetch.txt'
         );
-        $fetch = new Fetch($bag, true);
-        return $fetch;
+        return new Fetch($bag, true);
     }
 
     /**
@@ -142,21 +141,28 @@ class FetchTest extends BagItTestFramework
     }
 
     /**
-     * Test destinations that have percent encoded characters other than
+     * Test destinations that have incorrect character encoded lines.
      * @group Fetch
      * @covers ::__construct
      * @covers ::loadFiles
      * @covers ::downloadAll
-     * @covers ::downloadFiles
-     * @covers ::validateData
-     * @covers ::validatePath
      */
     public function testDestinationOtherEncodedCharacters()
     {
-        $fetch = $this->setupBag('other-encoded-characters.txt');
-        $this->assertCount(0, $fetch->getErrors());
+        $fetch = $this->setupBag('bad-encoding.txt');
+        $this->assertCount(3, $fetch->getErrors());
+        $this->expectException(BagItException::class);
         $fetch->downloadAll();
-        $this->assertCount(1, $fetch->getErrors());
+    }
+
+    /**
+     * @group Fetch
+     * @covers ::loadFiles
+     */
+    public function testFetchFileCorrectlyEncodedCharacters(): void
+    {
+        $fetch = $this->setupBag('good-encoded-file-paths.txt');
+        $this->assertCount(0, $fetch->getErrors());
     }
 
     /**
@@ -664,5 +670,47 @@ class FetchTest extends BagItTestFramework
             'message' => "Failed to fetch URL (" . self::$remote_urls[4] . ") : Callback aborted",
         ];
         $this->assertEquals($expected, $bag->getErrors()[0]);
+    }
+
+    /**
+     * Ensure fetch files are written to disk encoded, but kept in memory as un-encoded.
+     * @group Fetch
+     * @covers ::writeToDisk
+     * @covers \whikloj\BagItTools\BagUtils::encodeFilepath
+     */
+    public function testCreateFetchWithEncodedCharacters(): void
+    {
+        $expected_on_disk = [
+            "data/file-with%0Anewline.txt",
+            "data/directory%0Dcarriage%0Dreturn/empty.txt",
+            "data/image-with-%25-character.jpg",
+            "data/already-encoded-%2525-double-it.txt",
+            "data/directory%0Dcarriage%0Dreturn/directory%0Aline%0Abreak/image-with-%2525.jpg",
+        ];
+        $expected_in_memory = [
+            "data/file-with\nnewline.txt",
+            "data/directory\rcarriage\rreturn/empty.txt",
+            "data/image-with-%-character.jpg",
+            "data/already-encoded-%25-double-it.txt",
+            "data/directory\rcarriage\rreturn/directory\nline\nbreak/image-with-%25.jpg",
+        ];
+        // Create a bag with fetch file destinations that are weird.
+        $bag = Bag::create($this->tmpdir);
+        $bag->setExtended(true);
+        for ($foo=0; $foo < count($expected_in_memory); $foo += 1) {
+            $bag->addFetchFile(self::$remote_urls[$foo], $expected_in_memory[$foo]);
+        }
+        $bag->update();
+        // Read the fetch.txt file from disk.
+        $fetch = explode("\n", file_get_contents($bag->getBagRoot() . DIRECTORY_SEPARATOR . "fetch.txt"));
+        $fetch = array_filter($fetch);
+        array_walk($fetch, function (&$o) {
+            $o = trim(explode(" ", $o)[2]);
+        });
+        // Verify the on disk fetch.txt file paths are as expected.
+        $this->assertArrayEquals($expected_on_disk, $fetch);
+        // Verify that the filepaths in memory remain decoded.
+        $manifest = $bag->getPayloadManifests()['sha512'];
+        $this->assertArrayEquals($expected_in_memory, array_keys($manifest->getHashes()));
     }
 }

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -150,7 +150,7 @@ class FetchTest extends BagItTestFramework
     public function testDestinationOtherEncodedCharacters()
     {
         $fetch = $this->setupBag('bad-encoding.txt');
-        $this->assertCount(3, $fetch->getErrors());
+        $this->assertCount(1, $fetch->getErrors());
         $this->expectException(BagItException::class);
         $fetch->downloadAll();
     }

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -218,10 +218,10 @@ class ManifestTest extends BagItTestFramework
         $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "TestBadFilePathsBag");
         $bag = Bag::load($this->tmpdir);
         $this->assertFalse($bag->validate());
-        // 3 errors for bad payload lines, 2 for missing files and 1 for files in the bag not in the payload manifest.
-        $this->assertCount(6, $bag->getErrors());
+        // 1 errors for bad payload lines, 1 for missing files and 1 for files in the bag not in the payload manifest.
+        $this->assertCount(3, $bag->getErrors());
         $payload = $bag->getPayloadManifests()['sha256'];
-        $this->assertCount(4, $payload->getHashes());
+        $this->assertCount(2, $payload->getHashes());
     }
 
     /**

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -154,6 +154,64 @@ class ManifestTest extends BagItTestFramework
     }
 
     /**
+     * Test decoding a bag with carriage returns, line breaks and % in file paths.
+     * @group Manifest
+     * @covers ::decodeFilepath
+     */
+    public function testLoadManifestWithSpecialCharacters(): void
+    {
+        $expected = [
+            "data/File-with-%0A-name.txt",
+            "data/carriage\rreturn-file.txt",
+            "data/directory\nline\nbreak/some-file.txt",
+            "data/directory\nline\nbreak/carriage\rreturn/Example-file-%-and-%25.txt",
+        ];
+        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "TestEncodingBag");
+        $bag = Bag::load($this->tmpdir);
+        $this->assertTrue($bag->validate());
+        $manifest = $bag->getPayloadManifests();
+        $paths = array_keys($manifest['sha256']->getHashes());
+        $this->assertArrayEquals($expected, $paths);
+    }
+
+    /**
+     * Test that carriage returns, line breaks and % characters are encoded on file paths in payload manifests.
+     * @group Manifest
+     * @covers ::encodeFilepath
+     */
+    public function testWriteManifestWithSpecialCharacters(): void
+    {
+        $expected = [
+            "data/file-with%0Anewline.txt",
+            "data/directory%0Dcarriage%0Dreturn/empty.txt",
+            "data/image-with-%25-character.jpg",
+            "data/already-encoded-%2525-double-it.txt",
+            "data/directory%0Dcarriage%0Dreturn/directory%0Aline%0Abreak/image-with-%2525.jpg",
+        ];
+        $bag = Bag::create($this->tmpdir);
+        $bag->addFile(self::TEST_TEXT['filename'], "file-with\nnewline.txt");
+        $bag->addFile(self::TEST_TEXT['filename'], "directory\rcarriage\rreturn/empty.txt");
+        $bag->addFile(self::TEST_IMAGE['filename'], "image-with-%-character.jpg");
+        $bag->addFile(self::TEST_TEXT['filename'], "already-encoded-%25-double-it.txt");
+        $bag->addFile(
+            self::TEST_IMAGE['filename'],
+            "directory\rcarriage\rreturn/directory\nline\nbreak/image-with-%25.jpg"
+        );
+        $bag->update();
+        // Read the lines from the manifest file.
+        $fp = fopen($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt', "r");
+        $paths = [];
+        while (!feof($fp)) {
+            $line = fgets($fp);
+            if ($line !== false) {
+                $path = explode(' ', $line)[1];
+                $paths[] = trim($path);
+            }
+        }
+        $this->assertArrayEquals($expected, $paths);
+    }
+
+    /**
      * Utility to set a bag with a specific manifest file.
      * @param string $manifest_filename
      *   File name from tests/resources/manifests to put in bag.

--- a/tests/resources/TestBadFilePathsBag/bagit.txt
+++ b/tests/resources/TestBadFilePathsBag/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 1.0
+Tag-File-Character-Encoding: UTF-8

--- a/tests/resources/TestBadFilePathsBag/data/fails-due-to-
-character.txt
+++ b/tests/resources/TestBadFilePathsBag/data/fails-due-to-
-character.txt
@@ -1,1 +1,0 @@
-This will fail because the LF character is not urlencoded in the payload manifest.

--- a/tests/resources/TestBadFilePathsBag/data/fails-due-to-
-character.txt
+++ b/tests/resources/TestBadFilePathsBag/data/fails-due-to-
-character.txt
@@ -1,0 +1,1 @@
+This will fail because the LF character is not urlencoded in the payload manifest.

--- a/tests/resources/TestBadFilePathsBag/data/file-with-%-and-%25-fails.txt
+++ b/tests/resources/TestBadFilePathsBag/data/file-with-%-and-%25-fails.txt
@@ -1,0 +1,1 @@
+This is a bad test because there is an unencoded % in the file path in the payload manifest.

--- a/tests/resources/TestBadFilePathsBag/data/this-file-will-be-fine-%-and-
.txt
+++ b/tests/resources/TestBadFilePathsBag/data/this-file-will-be-fine-%-and-
.txt
@@ -1,0 +1,1 @@
+This file will have correctly encoded paths in the payload manifest.

--- a/tests/resources/TestBadFilePathsBag/manifest-sha256.txt
+++ b/tests/resources/TestBadFilePathsBag/manifest-sha256.txt
@@ -1,0 +1,5 @@
+aa3f63965beb129caea530ca7e812dcc43052233ba7e6d73f0005dc1b69a4bf8  data/fails-due-to-
+-character.txt
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  data/This-fails-due-to--character.txt
+f65e9130dcfa5ae0db20557cf8e396242cca6a6c505c443587564f3b2b4ffc58  data/file-with-%-and-%25-fails.txt
+fffe60312df6e39971a95593557fcb17da5b9ebc2538634df37934a98c9a657e  data/this-file-will-be-fine-%25-and-%0A.txt

--- a/tests/resources/TestBadFilePathsBag/manifest-sha256.txt
+++ b/tests/resources/TestBadFilePathsBag/manifest-sha256.txt
@@ -1,5 +1,2 @@
-aa3f63965beb129caea530ca7e812dcc43052233ba7e6d73f0005dc1b69a4bf8  data/fails-due-to-
--character.txt
-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  data/This-fails-due-to--character.txt
 f65e9130dcfa5ae0db20557cf8e396242cca6a6c505c443587564f3b2b4ffc58  data/file-with-%-and-%25-fails.txt
 fffe60312df6e39971a95593557fcb17da5b9ebc2538634df37934a98c9a657e  data/this-file-will-be-fine-%25-and-%0A.txt

--- a/tests/resources/TestEncodingBag/bagit.txt
+++ b/tests/resources/TestEncodingBag/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 1.0
+Tag-File-Character-Encoding: UTF-8

--- a/tests/resources/TestEncodingBag/data/File-with-%0A-name.txt
+++ b/tests/resources/TestEncodingBag/data/File-with-%0A-name.txt
@@ -1,0 +1,1 @@
+This file name has an encoded % symbol that when decoded to from %25 to % become %0A which is an encoded line break.

--- a/tests/resources/TestEncodingBag/data/carriagereturn-file.txt
+++ b/tests/resources/TestEncodingBag/data/carriagereturn-file.txt
@@ -1,0 +1,1 @@
+This is some data in a file which filename has a carriage return.

--- a/tests/resources/TestEncodingBag/data/directory
line
break/carriagereturn/Example-file-%-and-%25.txt
+++ b/tests/resources/TestEncodingBag/data/directory
line
break/carriagereturn/Example-file-%-and-%25.txt
@@ -1,0 +1,1 @@
+This is a file with percent characters in the filename, inside a directory with a carriage return, inside a directory with line breaks.

--- a/tests/resources/TestEncodingBag/data/directory
line
break/some-file.txt
+++ b/tests/resources/TestEncodingBag/data/directory
line
break/some-file.txt
@@ -1,0 +1,1 @@
+This is a different file with some example text, the file is located in a directory which has url encoded line breaks.

--- a/tests/resources/TestEncodingBag/manifest-sha256.txt
+++ b/tests/resources/TestEncodingBag/manifest-sha256.txt
@@ -1,0 +1,4 @@
+762654958f1129415f3aec2baa72935dde0d9ce0ec06938a77a27ec48d6754aa  data/directory%0Aline%0Abreak/carriage%0Dreturn/Example-file-%25-and-%2525.txt
+99d0a905687235e157fe89c31d04de46b6261ce84cac3d6b7715825ed123be60  data/directory%0Aline%0Abreak/some-file.txt
+7c0ff6b2c3895970b6e696d1702adc572780c59aea722d09ab34b807bc2e0fba  data/carriage%0Dreturn-file.txt
+6d3bdfa7b318db3ce4efc2e3ade95ee0245ff38f1894802c1dd00203c6f335a1  data/File-with-%250A-name.txt

--- a/tests/resources/fetchFiles/bad-encoding.txt
+++ b/tests/resources/fetchFiles/bad-encoding.txt
@@ -1,4 +1,1 @@
 https://www.example.org/what/a/day 123456 dir1/dir3/dir4%2Ffile.txt
-https://example.org/this/is/demo - dir1/dir2/file--return.txt
-https://example.org/some/other/file 555 dir2/dir2/some
-file.txt

--- a/tests/resources/fetchFiles/bad-encoding.txt
+++ b/tests/resources/fetchFiles/bad-encoding.txt
@@ -1,0 +1,4 @@
+https://www.example.org/what/a/day 123456 dir1/dir3/dir4%2Ffile.txt
+https://example.org/this/is/demo - dir1/dir2/file--return.txt
+https://example.org/some/other/file 555 dir2/dir2/some
+file.txt

--- a/tests/resources/fetchFiles/good-encoded-file-paths.txt
+++ b/tests/resources/fetchFiles/good-encoded-file-paths.txt
@@ -1,0 +1,4 @@
+http://example.org/some/file/1 - data/some-file-%0A-with-LF.txt
+http://example.org/some/file/2 - data/some-file-%0D-with-CR.txt
+http://example.org/some/file/3 - data/some-file-%25.txt
+https://www.example.org/what/a/day 123456 dir1/dir3/dir4%252Ffile.txt

--- a/tests/resources/fetchFiles/other-encoded-characters.txt
+++ b/tests/resources/fetchFiles/other-encoded-characters.txt
@@ -1,1 +1,0 @@
-https://www.example.org/what/a/day 123456 dir1/dir3/dir4%2Ffile.txt


### PR DESCRIPTION
Resolves #33 

This change:
* Checks the payload manifests and fetch files of loaded Bags for any url encoded characters other than %0D, %0A and %25 and fails validation if it finds one. It also fails if it finds an unencoded newline or carriage return (though this really should never happen)
* Correctly urlencodes these characters in payload manifests and fetch files written out by this library
