### PR TITLE
Split BagIt spec files to allow for CR, LF or CRLF line endings

### DIFF
--- a/src/AbstractManifest.php
+++ b/src/AbstractManifest.php
@@ -230,14 +230,14 @@ abstract class AbstractManifest
         $this->resetLoadIssues();
         $fullPath = $this->bag->makeAbsolute($this->filename);
         if (file_exists($fullPath)) {
-            $fp = fopen($fullPath, "rb");
-            if ($fp === false) {
+            $file_contents = file_get_contents($fullPath);
+            if ($file_contents === false) {
                 throw new FilesystemException("Unable to read file {$fullPath}");
             }
             $lineCount = 0;
-            while (!feof($fp)) {
+            $lines = BagUtils::splitFileDataOnLineEndings($file_contents);
+            foreach ($lines as $line) {
                 $lineCount += 1;
-                $line = fgets($fp);
                 $line = $this->bag->decodeText($line);
                 $line = trim($line);
                 if (empty($line)) {
@@ -264,7 +264,6 @@ abstract class AbstractManifest
                     $this->addLoadError("Line $lineCount : Line is not of the form 'checksum path'");
                 }
             }
-            fclose($fp);
         }
     }
 

--- a/src/BagUtils.php
+++ b/src/BagUtils.php
@@ -414,4 +414,17 @@ class BagUtils
     {
         return preg_match_all("/%(?!(25|0A|0D))/", $filepath);
     }
+
+    /**
+     * Split the file data on any of the allowed line endings.
+     *
+     * @param string $data
+     *   The file data as a single string.
+     * @return array
+     *   Array split on \r\n, \r, and \n
+     */
+    public static function splitFileDataOnLineEndings(string $data): array
+    {
+        return preg_split("/(\r\n|\r|\n)/", $data);
+    }
 }

--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -330,14 +330,14 @@ class Fetch
     {
         $this->resetErrors();
         if (file_exists($this->filename)) {
-            $fp = fopen($this->filename, "rb");
-            if ($fp === false) {
+            $file_contents = file_get_contents($this->filename);
+            if ($file_contents === false) {
                 throw new FilesystemException("Unable to read file {$this->filename}");
             }
             $lineCount = 0;
-            while (!feof($fp)) {
+            $lines = BagUtils::splitFileDataOnLineEndings($file_contents);
+            foreach ($lines as $line) {
                 $lineCount += 1;
-                $line = fgets($fp);
                 $line = $this->bag->decodeText($line);
                 $line = trim($line);
                 if (empty($line)) {
@@ -364,7 +364,7 @@ class Fetch
                         'destination' => $destination,
                     ];
                 } else {
-                    $this->addError("Line $lineCount : This line is not valid.");
+                    $this->addError("Line $lineCount: This line is not valid.");
                 }
             }
         }

--- a/tests/BagUtilsTest.php
+++ b/tests/BagUtilsTest.php
@@ -110,7 +110,7 @@ class BagUtilsTest extends BagItTestFramework
         $this->assertCount(2, $files);
 
         $files = BagUtils::getAllFiles(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'fetchFiles');
-        $this->assertCount(5, $files);
+        $this->assertCount(8, $files);
 
         $files = BagUtils::getAllFiles(self::TEST_EXTENDED_BAG_DIR);
         $this->assertCount(7, $files);

--- a/tests/ExtendedBagTest.php
+++ b/tests/ExtendedBagTest.php
@@ -533,4 +533,89 @@ class ExtendedBagTest extends BagItTestFramework
         $this->assertEquals("This is some crazy information about a new way of searching for : the stuff. " .
             "Why do this? Because we can.", $testbag2->getBagInfoByTag('External-Description')[0]);
     }
+
+    /**
+     * Repeat the reading of a bag but with CR instead of LF endings.
+     *
+     * @covers \whikloj\BagItTools\AbstractManifest::loadFile
+     *
+     * @see \whikloj\BagItTools\Test\ExtendedBagTest::testLoadExtendedBag()
+     */
+    public function testLoadExtendedCRLineEndings(): void
+    {
+        $this->tmpdir = $this->prepareExtendedTestBag();
+        $this->switchLineEndingsTo("\r");
+
+        $bag = Bag::load($this->tmpdir);
+        $this->assertTrue($bag->isExtended());
+        $payloads = $bag->getPayloadManifests();
+        $tags = $bag->getTagManifests();
+        $this->assertCount(1, $payloads);
+        $this->assertCount(1, $tags);
+        $this->assertArrayHasKey('sha1', $payloads);
+        $this->assertArrayHasKey('sha1', $tags);
+        $this->assertCount(2, $payloads['sha1']->getHashes());
+        $this->assertCount(4, $tags['sha1']->getHashes());
+        $this->assertArrayHasKey('bagit.txt', $tags['sha1']->getHashes());
+        $this->assertArrayHasKey('bag-info.txt', $tags['sha1']->getHashes());
+        $this->assertArrayHasKey('manifest-sha1.txt', $tags['sha1']->getHashes());
+        $this->assertArrayHasKey('alt_tags/random_tags.txt', $tags['sha1']->getHashes());
+        $this->assertTrue($bag->hasBagInfoTag('contact-phone'));
+        $this->assertFalse($bag->hasBagInfoTag('payload-oxum'));
+        $this->assertFalse($bag->hasBagInfoTag('bag-size'));
+    }
+
+    /**
+     * Repeat the reading of a bag but with CRLF instead of just LF endings.
+     *
+     * @covers \whikloj\BagItTools\AbstractManifest::loadFile
+     *
+     * @see \whikloj\BagItTools\Test\ExtendedBagTest::testLoadExtendedBag()
+     */
+    public function testLoadExtendedCRLFLineEndings(): void
+    {
+        $this->tmpdir = $this->prepareExtendedTestBag();
+        $this->switchLineEndingsTo("\r\n");
+
+        $bag = Bag::load($this->tmpdir);
+        $this->assertTrue($bag->isExtended());
+        $payloads = $bag->getPayloadManifests();
+        $tags = $bag->getTagManifests();
+        $this->assertCount(1, $payloads);
+        $this->assertCount(1, $tags);
+        $this->assertArrayHasKey('sha1', $payloads);
+        $this->assertArrayHasKey('sha1', $tags);
+        $this->assertCount(2, $payloads['sha1']->getHashes());
+        $this->assertCount(4, $tags['sha1']->getHashes());
+        $this->assertArrayHasKey('bagit.txt', $tags['sha1']->getHashes());
+        $this->assertArrayHasKey('bag-info.txt', $tags['sha1']->getHashes());
+        $this->assertArrayHasKey('manifest-sha1.txt', $tags['sha1']->getHashes());
+        $this->assertArrayHasKey('alt_tags/random_tags.txt', $tags['sha1']->getHashes());
+        $this->assertTrue($bag->hasBagInfoTag('contact-phone'));
+        $this->assertFalse($bag->hasBagInfoTag('payload-oxum'));
+        $this->assertFalse($bag->hasBagInfoTag('bag-size'));
+    }
+
+    /**
+     * Switch the line endings of the test extended bag from \r to
+     *
+     * @param string $newEnding
+     *   What to switch the line endings to.
+     */
+    private function switchLineEndingsTo(string $newEnding): void
+    {
+        $files = [
+            "bagit.txt",
+            "bag-info.txt",
+            "manifest-sha1.txt",
+            "tagmanifest-sha1.txt",
+        ];
+        foreach ($files as $file) {
+            $path = $this->tmpdir . DIRECTORY_SEPARATOR . $file;
+            file_put_contents(
+                $path,
+                str_replace("\n", $newEnding, file_get_contents($path))
+            );
+        }
+    }
 }

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -713,4 +713,34 @@ class FetchTest extends BagItTestFramework
         $manifest = $bag->getPayloadManifests()['sha512'];
         $this->assertArrayEquals($expected_in_memory, array_keys($manifest->getHashes()));
     }
+
+    public function testReadCRLineEndings(): void
+    {
+        $fetch = $this->setupBag('fetch-CR.txt');
+        $this->assertCount(0, $fetch->getErrors());
+        $cr_data = $fetch->getData();
+        $this->assertCount(2, $cr_data);
+        $this->assertTrue(in_array('http://example.org/some/file/1', array_column($cr_data, 'uri')));
+        $this->assertTrue(in_array('http://example.org/some/file/2', array_column($cr_data, 'uri')));
+    }
+
+    public function testReadLFLineEndings(): void
+    {
+        $fetch = $this->setupBag('fetch-LF.txt');
+        $this->assertCount(0, $fetch->getErrors());
+        $cr_data = $fetch->getData();
+        $this->assertCount(2, $cr_data);
+        $this->assertTrue(in_array('http://example.org/some/file/1', array_column($cr_data, 'uri')));
+        $this->assertTrue(in_array('http://example.org/some/file/2', array_column($cr_data, 'uri')));
+    }
+
+    public function testReadCRLFLineEndings(): void
+    {
+        $fetch = $this->setupBag('fetch-CRLF.txt');
+        $this->assertCount(0, $fetch->getErrors());
+        $cr_data = $fetch->getData();
+        $this->assertCount(2, $cr_data);
+        $this->assertTrue(in_array('http://example.org/some/file/1', array_column($cr_data, 'uri')));
+        $this->assertTrue(in_array('http://example.org/some/file/2', array_column($cr_data, 'uri')));
+    }
 }

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -225,6 +225,30 @@ class ManifestTest extends BagItTestFramework
     }
 
     /**
+     * Ensure we properly load manifests with CR line endings only.
+     */
+    public function testLoadBagWithCRLineEndings(): void
+    {
+        $this->prepareManifest("TestBag-manifest-CR-sha256.txt");
+        $bag = Bag::load($this->tmpdir);
+        $this->assertTrue($bag->validate());
+        $payload = $bag->getPayloadManifests()['sha256'];
+        $this->assertCount(3, $payload->getHashes());
+    }
+
+    /**
+     * Ensure we properly load manifests with CRLF line endings only.
+     */
+    public function testLoadBagWithCRLFLineEndings(): void
+    {
+        $this->prepareManifest("TestBag-manifest-CRLF-sha256.txt");
+        $bag = Bag::load($this->tmpdir);
+        $this->assertTrue($bag->validate());
+        $payload = $bag->getPayloadManifests()['sha256'];
+        $this->assertCount(3, $payload->getHashes());
+    }
+
+    /**
      * Utility to set a bag with a specific manifest file.
      * @param string $manifest_filename
      *   File name from tests/resources/manifests to put in bag.

--- a/tests/resources/fetchFiles/fetch-CR.txt
+++ b/tests/resources/fetchFiles/fetch-CR.txt
@@ -1,0 +1,1 @@
+http://example.org/some/file/1 - data/some-file.txthttp://example.org/some/file/2 - data/some-other-file.txt

--- a/tests/resources/fetchFiles/fetch-CRLF.txt
+++ b/tests/resources/fetchFiles/fetch-CRLF.txt
@@ -1,0 +1,2 @@
+http://example.org/some/file/1 - data/some-file.txt
+http://example.org/some/file/2 - data/some-other-file.txt

--- a/tests/resources/fetchFiles/fetch-LF.txt
+++ b/tests/resources/fetchFiles/fetch-LF.txt
@@ -1,0 +1,2 @@
+http://example.org/some/file/1 - data/some-file.txt
+http://example.org/some/file/2 - data/some-other-file.txt

--- a/tests/resources/manifests/TestBag-manifest-CR-sha256.txt
+++ b/tests/resources/manifests/TestBag-manifest-CR-sha256.txt
@@ -1,0 +1,1 @@
+3663a4f1d58f56248bf3708a27c1f143a9ec96ea5dbb78d627a4330b73f8b6db  data/jekyll_and_hyde.txt0fd56c020e20bf86fd89b3357b30203c684411afca5c7aa98023f32f7536e936  data/pictures/another_picture.txt2c9d71a5db0a38b99b897f2397f7e252f451a7d219d044a47f22ffd3637e64e3  data/pictures/some_more_data.txt

--- a/tests/resources/manifests/TestBag-manifest-CRLF-sha256.txt
+++ b/tests/resources/manifests/TestBag-manifest-CRLF-sha256.txt
@@ -1,0 +1,3 @@
+3663a4f1d58f56248bf3708a27c1f143a9ec96ea5dbb78d627a4330b73f8b6db  data/jekyll_and_hyde.txt
+0fd56c020e20bf86fd89b3357b30203c684411afca5c7aa98023f32f7536e936  data/pictures/another_picture.txt
+2c9d71a5db0a38b99b897f2397f7e252f451a7d219d044a47f22ffd3637e64e3  data/pictures/some_more_data.txt


### PR DESCRIPTION
Resolves #36 