### PR TITLE
More code cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "phpdocumentor/phpdocumentor": "^3.0",
     "sebastian/phpcpd": "^6.0",
     "squizlabs/php_codesniffer": "^3.5",
-    "donatj/mock-webserver": "^2.1"
+    "donatj/mock-webserver": "^2.1",
+    "phpstan/phpstan": "^1.4"
   },
   "autoload": {
     "psr-4": {
@@ -38,13 +39,19 @@
     }
   },
   "scripts": {
+    "phpstan": [
+      "php -d memory_limit=-1 ./vendor/bin/phpstan analyze -l 3 src tests"
+    ],
     "check": [
       "./vendor/bin/phpcs --standard=PSR12 src tests",
       "./vendor/bin/phpcpd --suffix='.php' src"
     ],
+    "phpunit": [
+      "phpdbg -qrr ./vendor/bin/phpunit"
+    ],
     "test": [
       "@check",
-      "phpdbg -qrr ./vendor/bin/phpunit"
+      "@phpunit"
     ]
   },
   "config": {

--- a/src/Bag.php
+++ b/src/Bag.php
@@ -155,14 +155,14 @@ class Bag
      *
      * @var array
      */
-    private $currentVersion;
+    private $currentVersion = self::DEFAULT_BAGIT_VERSION;
 
     /**
      * Current bag file encoding.
      *
      * @var string
      */
-    private $currentFileEncoding = null;
+    private $currentFileEncoding = self::DEFAULT_FILE_ENCODING;
 
     /**
      * Array of payload manifests.
@@ -449,8 +449,7 @@ class Bag
             } elseif (isset($this->fetchFile) && $this->fetchFile->reservedPath($dest)) {
                 throw new BagItException("The path ($dest) is used in the fetch.txt file.");
             } else {
-                $fullDest = $this->makeAbsolute($dest);
-                $fullDest = Normalizer::normalize($fullDest);
+                $fullDest = Normalizer::normalize($this->makeAbsolute($dest));
                 if (file_exists($fullDest)) {
                     throw new BagItException("File $dest already exists in the bag.");
                 }
@@ -701,13 +700,8 @@ class Bag
         $charset = BagUtils::getValidCharset($encoding);
         if (is_null($charset)) {
             throw new BagItException("Character set $encoding is not supported.");
-        } else {
-            if ($encoding == self::trimLower(self::DEFAULT_FILE_ENCODING)) {
-                // go back to default.
-                unset($this->currentFileEncoding);
-            } else {
-                $this->currentFileEncoding = $charset;
-            }
+        } elseif (strcasecmp($encoding, $this->currentFileEncoding) !== 0) {
+            $this->currentFileEncoding = $charset;
             $this->changed = true;
         }
     }
@@ -720,10 +714,7 @@ class Bag
      */
     public function getFileEncoding(): string
     {
-        if (isset($this->currentFileEncoding)) {
-            return $this->currentFileEncoding;
-        }
-        return self::DEFAULT_FILE_ENCODING;
+        return $this->currentFileEncoding;
     }
 
     /**
@@ -927,10 +918,7 @@ class Bag
      */
     public function getVersion(): array
     {
-        if (isset($this->currentVersion)) {
-            return $this->currentVersion;
-        }
-        return self::DEFAULT_BAGIT_VERSION;
+        return $this->currentVersion;
     }
 
     /**
@@ -1125,7 +1113,7 @@ class Bag
             if (count($hashes) == 1 && $hashes[0] == 'md5') {
                 $this->setAlgorithm(self::DEFAULT_HASH_ALGORITHM);
             }
-            unset($this->currentVersion);
+            $this->currentVersion = self::DEFAULT_BAGIT_VERSION;
             $this->update();
         }
     }

--- a/src/Bag.php
+++ b/src/Bag.php
@@ -372,6 +372,7 @@ class Bag
      *   If problems updating the bag.
      * @deprecated 4.1.0 Name change of same function to better signify the boolean response
      * @see \whikloj\BagItTools\Bag::isValid()
+     * @codeCoverageIgnore
      */
     public function validate(): bool
     {

--- a/src/Bag.php
+++ b/src/Bag.php
@@ -1244,12 +1244,12 @@ class Bag
                         $previousValue = $bagData[count($bagData) - 1]['value'];
                         // Add a space only if the previous character was not a line break.
                         $lastChar = substr($previousValue, -1);
-                        $previousValue .= ($lastChar != "\r" && $lastChar != "\n" ? " " : "");
-                        $previousValue .= Bag::trimSpacesOnly($line);
                         if ($lineLength >= Bag::BAGINFO_AUTOWRAP_GUESS_LENGTH) {
                             // Line is max length or longer, should be autowrapped
                             $previousValue = rtrim($previousValue, "\r\n");
                         }
+                        $previousValue .= ($lastChar != "\r" && $lastChar != "\n" ? " " : "");
+                        $previousValue .= Bag::trimSpacesOnly($line);
                         $bagData[count($bagData) - 1]['value'] = $previousValue;
                     } else {
                         $this->addBagError(
@@ -1260,12 +1260,12 @@ class Bag
                 } elseif (preg_match("~^(\s+)?([^:]+?)(\s+)?:(.*)~", $line, $matches)) {
                     // First line
                     $current_tag = $matches[2];
-                    if ($this->mustNotRepeatBagInfoExists($current_tag)) {
+                    if (self::mustNotRepeatBagInfoExists($current_tag, $bagData)) {
                         $this->addBagError(
                             $info_file,
                             "Line $lineCount: Tag $current_tag MUST not be repeated."
                         );
-                    } elseif ($this->shouldNotRepeatBagInfoExists($current_tag)) {
+                    } elseif (self::shouldNotRepeatBagInfoExists($current_tag, $bagData)) {
                         $this->addBagWarning(
                             $info_file,
                             "Line $lineCount: Tag $current_tag SHOULD NOT be repeated."
@@ -2286,28 +2286,30 @@ class Bag
      * Check that the key is not non-repeatable and already in the bagInfo.
      *
      * @param string $key The key being added.
+     * @param array $bagData The current bag data.
      *
      * @return boolean
      *   True if the key is non-repeatable and already in the
      */
-    private function mustNotRepeatBagInfoExists(string $key): bool
+    private static function mustNotRepeatBagInfoExists(string $key, array $bagData): bool
     {
         return (in_array(strtolower($key), self::BAG_INFO_MUST_NOT_REPEAT) &&
-            self::arrayKeyExistsNoCase($key, 'tag', $this->bagInfoData));
+            self::arrayKeyExistsNoCase($key, 'tag', $bagData));
     }
 
     /**
      * Check that the key is not non-repeatable and already in the bagInfo.
      *
      * @param string $key The key being added.
+     * @param array $bagData The current bag data.
      *
      * @return boolean
      *   True if the key is non-repeatable and already in the
      */
-    private function shouldNotRepeatBagInfoExists(string $key): bool
+    private static function shouldNotRepeatBagInfoExists(string $key, array $bagData): bool
     {
         return (in_array(strtolower($key), self::BAG_INFO_SHOULD_NOT_REPEAT) &&
-            self::arrayKeyExistsNoCase($key, 'tag', $this->bagInfoData));
+            self::arrayKeyExistsNoCase($key, 'tag', $bagData));
     }
 
     /**

--- a/src/BagUtils.php
+++ b/src/BagUtils.php
@@ -277,7 +277,7 @@ class BagUtils
      *
      * @param string $path
      *   The path of the file.
-     * @param mixed $contents
+     * @param string $contents
      *   The contents to put
      * @param int $flags
      *   Flags to pass on to file_put_contents.

--- a/src/Commands/ValidateCommand.php
+++ b/src/Commands/ValidateCommand.php
@@ -60,7 +60,7 @@ class ValidateCommand extends Command
                     $path = $realpath;
                 }
                 $bag = Bag::load($path);
-                $valid = $bag->validate();
+                $valid = $bag->isValid();
                 $verbose = $output->getVerbosity();
                 if ($verbose >= OutputInterface::VERBOSITY_VERBOSE) {
                     // Print warnings

--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -434,12 +434,12 @@ class Fetch
      *   The URL to download.
      * @param bool $single
      *   If this is a download() call versus a downloadAll() call.
-     * @param int|null size
+     * @param int|null $size
      *   Expected download size or null if unknown
      * @return false|resource
      *   False on error, otherwise the cUl resource.
      */
-    private function createCurl(string $url, bool $single = false, int $size = null)
+    private function createCurl(string $url, bool $single = false, ?int $size = null)
     {
         $ch = curl_init($url);
         $options = $this->curlOptions;

--- a/tests/BagInternalTest.php
+++ b/tests/BagInternalTest.php
@@ -188,7 +188,7 @@ class BagInternalTest extends BagItTestFramework
         $bag = Bag::load($this->tmpdir);
         $this->assertEquals('0.97', $bag->getVersionString());
         touch($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'oops.txt');
-        $this->assertFalse($bag->validate());
+        $this->assertFalse($bag->isValid());
         $this->assertCount(1, $bag->getErrors());
         $this->assertCount(2, $bag->getWarnings());
 

--- a/tests/BagTest.php
+++ b/tests/BagTest.php
@@ -29,7 +29,7 @@ class BagTest extends BagItTestFramework
         $this->assertTrue(is_file($this->tmpdir . DIRECTORY_SEPARATOR . "bagit.txt"));
         $this->assertFileExists($this->tmpdir . DIRECTORY_SEPARATOR . "data");
         $this->assertTrue(is_dir($this->tmpdir . DIRECTORY_SEPARATOR . "data"));
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
     }
 
     /**
@@ -42,7 +42,7 @@ class BagTest extends BagItTestFramework
     {
         $this->assertFileDoesNotExist($this->tmpdir);
         $bag = Bag::create($this->tmpdir);
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
     }
 
     /**
@@ -60,7 +60,7 @@ class BagTest extends BagItTestFramework
         $curr = getcwd();
         chdir($this->tmpdir);
         $bag = Bag::create("some-new-dir");
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $this->assertDirectoryExists($newDir);
         chdir($curr);
     }
@@ -78,7 +78,7 @@ class BagTest extends BagItTestFramework
         $curr = getcwd();
         chdir($this->tmpdir);
         $bag = Bag::create("./some-new-dir");
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $this->assertDirectoryExists($newDir);
         chdir($curr);
     }
@@ -92,7 +92,7 @@ class BagTest extends BagItTestFramework
    * @covers ::loadBagInfo
    * @covers ::loadTagManifests
    * @covers ::isExtended
-   * @covers ::validate
+   * @covers ::isValid
    * @covers \whikloj\BagItTools\AbstractManifest::loadFile
    * @covers \whikloj\BagItTools\AbstractManifest::cleanUpRelPath
    * @covers \whikloj\BagItTools\AbstractManifest::addToNormalizedList
@@ -104,7 +104,7 @@ class BagTest extends BagItTestFramework
         $this->assertCount(0, $bag->getErrors());
         $this->assertArrayHasKey('sha256', $bag->getPayloadManifests());
         $this->assertFalse($bag->isExtended());
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $this->assertCount(0, $bag->getErrors());
         $this->assertCount(0, $bag->getWarnings());
     }
@@ -568,7 +568,7 @@ class BagTest extends BagItTestFramework
     /**
      * Test getting a warning when validating an MD5 bag.
      * @group Bag
-     * @covers ::validate
+     * @covers ::isValid
      * @covers \whikloj\BagItTools\AbstractManifest::loadFile
      * @covers \whikloj\BagItTools\AbstractManifest::validate
      */
@@ -576,12 +576,12 @@ class BagTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareBasicTestBag();
         $bag = Bag::load($this->tmpdir);
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $this->assertCount(0, $bag->getWarnings());
         $bag->setAlgorithm('md5');
         $bag->update();
         $newBag = Bag::load($this->tmpdir);
-        $this->assertTrue($newBag->validate());
+        $this->assertTrue($newBag->isValid());
         $this->assertCount(1, $newBag->getWarnings());
     }
 
@@ -615,7 +615,7 @@ class BagTest extends BagItTestFramework
     public function testUncompressTarGz(): void
     {
         $bag = Bag::load(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'testtar.tgz');
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $this->assertTrue($bag->hasAlgorithm('sha224'));
         $manifest = $bag->getPayloadManifests()['sha224'];
         foreach ($manifest->getHashes() as $path => $hash) {
@@ -639,7 +639,7 @@ class BagTest extends BagItTestFramework
     public function testUncompressTarBzip(): void
     {
         $bag = Bag::load(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'testtar.tar.bz2');
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $this->assertTrue($bag->hasAlgorithm('sha224'));
         $manifest = $bag->getPayloadManifests()['sha224'];
         foreach ($manifest->getHashes() as $path => $hash) {
@@ -662,7 +662,7 @@ class BagTest extends BagItTestFramework
     public function testUncompressZip(): void
     {
         $bag = Bag::load(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'testzip.zip');
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $this->assertTrue($bag->hasAlgorithm('sha224'));
         $manifest = $bag->getPayloadManifests()['sha224'];
         foreach ($manifest->getHashes() as $path => $hash) {
@@ -694,7 +694,7 @@ class BagTest extends BagItTestFramework
         $this->assertFileExists($archivefile);
 
         $newbag = Bag::load($archivefile);
-        $this->assertTrue($newbag->validate());
+        $this->assertTrue($newbag->isValid());
 
         $this->assertEquals(
             $bag->getPayloadManifests()['sha256']->getHashes(),
@@ -722,7 +722,7 @@ class BagTest extends BagItTestFramework
         $this->assertFileExists($archivefile);
 
         $newbag = Bag::load($archivefile);
-        $this->assertTrue($newbag->validate());
+        $this->assertTrue($newbag->isValid());
 
         $this->assertEquals(
             $bag->getPayloadManifests()['sha256']->getHashes(),
@@ -750,7 +750,7 @@ class BagTest extends BagItTestFramework
         $this->assertFileExists($archivefile);
 
         $newbag = Bag::load($archivefile);
-        $this->assertTrue($newbag->validate());
+        $this->assertTrue($newbag->isValid());
 
         $this->assertEquals(
             $bag->getPayloadManifests()['sha256']->getHashes(),
@@ -778,7 +778,7 @@ class BagTest extends BagItTestFramework
         $this->assertFileExists($archivefile);
 
         $newbag = Bag::load($archivefile);
-        $this->assertTrue($newbag->validate());
+        $this->assertTrue($newbag->isValid());
 
         $this->assertEquals(
             $bag->getPayloadManifests()['sha256']->getHashes(),
@@ -822,7 +822,7 @@ class BagTest extends BagItTestFramework
         $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'Test097Bag');
         $bag = Bag::load($this->tmpdir);
         $this->assertEquals('0.97', $bag->getVersionString());
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $fp = fopen($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt', 'r');
         while (!feof($fp)) {
             $line = (string) fgets($fp);
@@ -836,7 +836,7 @@ class BagTest extends BagItTestFramework
         fclose($fp);
         $bag->upgrade();
         $this->assertEquals('1.0', $bag->getVersionString());
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $fp = fopen($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt', 'r');
         while (!feof($fp)) {
             $line = (string) fgets($fp);
@@ -896,7 +896,7 @@ class BagTest extends BagItTestFramework
         $bag = Bag::load($this->tmpdir);
         $this->assertEquals('0.97', $bag->getVersionString());
         touch($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'oops.txt');
-        $this->assertFalse($bag->validate());
+        $this->assertFalse($bag->isValid());
         $bag->upgrade();
     }
 
@@ -905,13 +905,13 @@ class BagTest extends BagItTestFramework
      * @covers ::__construct
      * @covers ::createNewBag
      * @covers ::update
-     * @covers ::validate
+     * @covers ::isValid
      */
     public function testEmptyBagShouldValidate(): void
     {
         $this->assertFileDoesNotExist($this->tmpdir);
         $bag = Bag::create($this->tmpdir);
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
     }
 
     /**

--- a/tests/ExtendedBagTest.php
+++ b/tests/ExtendedBagTest.php
@@ -15,6 +15,11 @@ use whikloj\BagItTools\Exceptions\BagItException;
 class ExtendedBagTest extends BagItTestFramework
 {
     /**
+     * @var string The directory to the bag-info files.
+     */
+    private const BAG_INFO_DIR = self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "bag-infos";
+
+    /**
      * @group Extended
      * @covers ::isValid
      * @covers ::getErrors
@@ -369,8 +374,10 @@ class ExtendedBagTest extends BagItTestFramework
     public function testInvalidBagInfov1(): void
     {
         $bag = Bag::create($this->tmpdir);
-        copy(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'bag-infos' . DIRECTORY_SEPARATOR .
-            'invalid-leading-spaces.txt', $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt');
+        copy(
+            self::BAG_INFO_DIR . DIRECTORY_SEPARATOR . 'invalid-leading-spaces.txt',
+            $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt'
+        );
         touch($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-md5.txt');
         $testbag = Bag::load($this->tmpdir);
         $this->assertCount(2, $testbag->getErrors());
@@ -385,8 +392,10 @@ class ExtendedBagTest extends BagItTestFramework
     public function testInvalidBagInfov097(): void
     {
         $bag = Bag::create($this->tmpdir);
-        copy(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'bag-infos' . DIRECTORY_SEPARATOR .
-            'invalid-leading-spaces.txt', $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt');
+        copy(
+            self::BAG_INFO_DIR . DIRECTORY_SEPARATOR . 'invalid-leading-spaces.txt',
+            $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt'
+        );
         file_put_contents(
             $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bagit.txt',
             "BagIt-Version: 0.97" . PHP_EOL . "Tag-File-Character-Encoding: UTF-8" . PHP_EOL
@@ -517,8 +526,10 @@ class ExtendedBagTest extends BagItTestFramework
     public function testLoadWrappedLines(): void
     {
         $bag = Bag::create($this->tmpdir);
-        copy(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'bag-infos' . DIRECTORY_SEPARATOR .
-            'long-lines-and-line-returns.txt', $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt');
+        copy(
+            self::BAG_INFO_DIR . DIRECTORY_SEPARATOR . 'long-lines-and-line-returns.txt',
+            $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt'
+        );
         touch($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
 
         // Load tag values as they exist on disk. Long lines (over 70 characters) get the newline removed
@@ -651,5 +662,99 @@ class ExtendedBagTest extends BagItTestFramework
             "Line 1: Appears to be continuation but there is no preceding tag.",
             $bag->getErrors()[0]["message"]
         );
+    }
+
+    /**
+     * Ensure that a bag-info that has lines over 77 characters get autowrapped.
+     * @covers ::loadBagInfo
+     */
+    public function testBagInfoWithLongLines(): void
+    {
+        $expected = [
+            "tag" => "External-Description",
+            "value" => "This is the start of a very long information that" .
+            " is expected to wrap on to the next line eventually. This action will cause the line that comes" .
+            " next to be placed directly in line with above line, no newline."
+        ];
+        $this->tmpdir = $this->prepareExtendedTestBag();
+        // Alter the bag-info.txt
+        file_put_contents(
+            $this->tmpdir . DIRECTORY_SEPARATOR . 'bag-info.txt',
+            "External-Description: This is the start of a very long information that" .
+            " is expected to wrap on to the next line eventually. This action will cause the line that comes\n" .
+            "\tnext to be placed directly in line with above line, no newline."
+        );
+        // Update the hash for bag-info.txt
+        file_put_contents(
+            $this->tmpdir . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt',
+            "bec1f727e714a0821610c4a2b28f9b0ef48e086b  bag-info.txt\n8010d7758f1793d0221c529fef818ff988dda141  " .
+            "bagit.txt\nfdead00cc124f82eef20c051e699518c43adc561  manifest-sha1.txt\n" .
+            "e939f78371e07a59c7a91e113618fd70cfa1e7ca  alt_tags/random_tags.txt\n"
+        );
+        $bag = Bag::load($this->tmpdir);
+        $this->assertTrue($bag->isValid());
+        $this->assertCount(0, $bag->getErrors());
+        $this->assertCount(1, $bag->getBagInfoData());
+        $this->assertArrayEquals($expected, $bag->getBagInfoData()[0]);
+    }
+
+    /**
+     * Ensure that MUST not repeat fields are flagged as errors on load
+     * @covers ::loadBagInfo
+     * @covers ::mustNotRepeatBagInfoExists
+     */
+    public function testMustNotRepeatBagInfoTags(): void
+    {
+        $this->tmpdir = $this->prepareExtendedTestBag();
+        file_put_contents(
+            $this->tmpdir . DIRECTORY_SEPARATOR . "bag-info.txt",
+            "Payload-Oxum: 19845.3\nSource-Organization: Museum of Arts and Crafts\nPayload-Oxum: 19845.3\n" .
+            "External-Description: This file will fail because you can only have one payload-oxum line.\n"
+        );
+        file_put_contents(
+            $this->tmpdir . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt',
+            "39546af37cf32cfce71b8d88a4aa4829105e11e6  bag-info.txt\n8010d7758f1793d0221c529fef818ff988dda141  " .
+            "bagit.txt\nfdead00cc124f82eef20c051e699518c43adc561  manifest-sha1.txt\n" .
+            "e939f78371e07a59c7a91e113618fd70cfa1e7ca  alt_tags/random_tags.txt\n"
+        );
+        $bag = Bag::load($this->tmpdir);
+        $this->assertFalse($bag->isValid());
+        $this->assertCount(1, $bag->getErrors());
+        $expected = [
+            "file" => "bag-info.txt",
+            "message" => "Line 3: Tag Payload-Oxum MUST not be repeated."
+        ];
+        $this->assertArrayEquals($expected, $bag->getErrors()[0]);
+    }
+
+    /**
+     * Ensure that SHOULD not repeat fields are flagged as warnings on load
+     * @covers ::loadBagInfo
+     * @covers ::shouldNotRepeatBagInfoExists
+     */
+    public function testShouldNotRepeatBagInfoTags(): void
+    {
+        $this->tmpdir = $this->prepareExtendedTestBag();
+        file_put_contents(
+            $this->tmpdir . DIRECTORY_SEPARATOR . "bag-info.txt",
+            "Payload-Oxum: 19845.3\nBag-Size: 2MB\nSource-Organization: Museum of Arts and Crafts\n" .
+            "External-Description: This file will fail because you can only have one payload-oxum line.\n" .
+            "Bag-Size: 2MB\n"
+        );
+        file_put_contents(
+            $this->tmpdir . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt',
+            "1a8c17edfec75662a05fad0276a08212af53c656  bag-info.txt\n8010d7758f1793d0221c529fef818ff988dda141  " .
+            "bagit.txt\nfdead00cc124f82eef20c051e699518c43adc561  manifest-sha1.txt\n" .
+            "e939f78371e07a59c7a91e113618fd70cfa1e7ca  alt_tags/random_tags.txt\n"
+        );
+        $bag = Bag::load($this->tmpdir);
+        $this->assertTrue($bag->isValid());
+        $this->assertCount(0, $bag->getErrors());
+        $this->assertCount(1, $bag->getWarnings());
+        $expected = [
+            "file" => "bag-info.txt",
+            "message" => "Line 5: Tag Bag-Size SHOULD NOT be repeated."
+        ];
+        $this->assertArrayEquals($expected, $bag->getWarnings()[0]);
     }
 }

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -477,7 +477,7 @@ class FetchTest extends BagItTestFramework
             $this->assertArrayHasKey($dest, $hashes);
             $this->assertFileDoesNotExist($newbag->makeAbsolute($dest));
         }
-        $this->assertTrue($newbag->validate());
+        $this->assertTrue($newbag->isValid());
         foreach ($destinations as $dest) {
             $dest = BagUtils::getAbsolute(BagUtils::baseInData($dest));
             $this->assertArrayHasKey($dest, $hashes);
@@ -569,7 +569,7 @@ class FetchTest extends BagItTestFramework
             $this->assertArrayHasKey($dest, $hashes);
             $this->assertFileDoesNotExist($newbag->makeAbsolute($dest));
         }
-        $this->assertFalse($newbag->validate());
+        $this->assertFalse($newbag->isValid());
         $this->assertCount(1, $newbag->getErrors());
         $hashes = $newbag->getPayloadManifests()['sha512']->getHashes();
         for ($foo = 0; $foo < 2; $foo += 1) {
@@ -678,7 +678,7 @@ class FetchTest extends BagItTestFramework
             self::$remote_urls[4] . " 2 data/download1.jpg\n"
         );
         $bag = Bag::load($this->tmpdir);
-        $this->assertFalse($bag->validate());
+        $this->assertFalse($bag->isValid());
         $this->assertFileDoesNotExist($bag->makeAbsolute('data/download1.jpg'));
         $expected = [
             'file' => 'fetch.txt',

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -100,10 +100,10 @@ class ManifestTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareExtendedTestBag();
         $bag = Bag::load($this->tmpdir);
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
 
         file_put_contents($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'oops.txt', "Slip up");
-        $this->assertFalse($bag->validate());
+        $this->assertFalse($bag->isValid());
     }
 
     /**
@@ -117,7 +117,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->prepareManifest('manifest-with-relative-paths-sha256.txt');
         $bag = Bag::load($this->tmpdir);
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $this->assertCount(0, $bag->getErrors());
         $this->assertCount(1, $bag->getWarnings());
     }
@@ -133,7 +133,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->prepareManifest('manifest-with-duplicate-lines-sha256.txt');
         $bag = Bag::load($this->tmpdir);
-        $this->assertFalse($bag->validate());
+        $this->assertFalse($bag->isValid());
         $this->assertCount(1, $bag->getErrors());
         $this->assertCount(0, $bag->getWarnings());
     }
@@ -149,7 +149,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->prepareManifest('manifest-with-case-insensitive-duplicates-sha256.txt');
         $bag = Bag::load($this->tmpdir);
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $this->assertCount(0, $bag->getErrors());
         $this->assertCount(1, $bag->getWarnings());
     }
@@ -170,7 +170,7 @@ class ManifestTest extends BagItTestFramework
         ];
         $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "TestEncodingBag");
         $bag = Bag::load($this->tmpdir);
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $manifest = $bag->getPayloadManifests();
         $paths = array_keys($manifest['sha256']->getHashes());
         $this->assertArrayEquals($expected, $paths);
@@ -218,7 +218,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "TestBadFilePathsBag");
         $bag = Bag::load($this->tmpdir);
-        $this->assertFalse($bag->validate());
+        $this->assertFalse($bag->isValid());
         // 1 errors for bad payload lines, 1 for missing files and 1 for files in the bag not in the payload manifest.
         $this->assertCount(3, $bag->getErrors());
         $payload = $bag->getPayloadManifests()['sha256'];
@@ -232,7 +232,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->prepareManifest("TestBag-manifest-CR-sha256.txt");
         $bag = Bag::load($this->tmpdir);
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $payload = $bag->getPayloadManifests()['sha256'];
         $this->assertCount(3, $payload->getHashes());
     }
@@ -244,7 +244,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->prepareManifest("TestBag-manifest-CRLF-sha256.txt");
         $bag = Bag::load($this->tmpdir);
-        $this->assertTrue($bag->validate());
+        $this->assertTrue($bag->isValid());
         $payload = $bag->getPayloadManifests()['sha256'];
         $this->assertCount(3, $payload->getHashes());
     }


### PR DESCRIPTION
* Add phpstan as an optional check for now
* Changes coming out of running phpstan
* Stop `unset()`ing to indicate a default value, just set it to the default.
* Rename `validate()` to `isValid()` to better indicate it returns a boolean.
* Add deprecation notice to `validate()`