### PR TITLE
Minor cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+* -text
 *.php eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.php eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         if: ${{ matrix.host-os != 'windows-latest' }}
 
       - name: Run test suite (Windows)
-        run: phpdbg -qrr ./vendor/bin/phpunit --verbose --debug --testsuite BagIt-Windows
+        run: phpdbg -qrr ./vendor/bin/phpunit --testsuite BagIt-Windows
         if: ${{ matrix.host-os == 'windows-latest' }}
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
             experimental: false
             host-os: "windows-latest"
 
-    name: PHP ${{ matrix.php-versions }}
+    name: PHP ${{ matrix.php-versions }} - OS ${{ matrix.host-os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,8 +57,13 @@ jobs:
       - name: Check codestyle
         run: composer check
 
-      - name: Run test suite
+      - name: Run test suite (Full)
         run: composer phpunit
+        if: ${{ matrix.host-os != 'windows-latest' }}
+
+      - name: Run test suite (Windows)
+        run: phpdbg -qrr ./vendor/bin/phpunit --verbose --debug --testsuite BagIt-Windows
+        if: ${{ matrix.host-os == 'windows-latest' }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["7.4", "8.0", "8.1"]
+        php-versions: ["8.0"]
+        host-os: ["windows-latest"]
         experimental: [false]
-        host-os: ["ubuntu-latest", "windows-latest"]
-        include:
-          - php-versions: "7.3"
-            experimental: false
-            host-os: "ubuntu-18.04"
-          - php-versions: "7.3"
-            experimental: false
-            host-os: "windows-latest"
+#        php-versions: ["7.4", "8.0", "8.1"]
+#        host-os: ["ubuntu-latest", "windows-latest"]
+#        include:
+#          - php-versions: "7.3"
+#            experimental: false
+#            host-os: "ubuntu-18.04"
+#          - php-versions: "7.3"
+#            experimental: false
+#            host-os: "windows-latest"
 
     name: PHP ${{ matrix.php-versions }} - OS ${{ matrix.host-os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: none
-          extensions: sockets, intl
+          extensions: sockets, intl, bz2
 
       - name: Get composer cache directory
         id: composercache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["7.4", "8.0"]
+        php-versions: ["7.4", "8.0", "8.1"]
         experimental: [false]
-        host-os: ["ubuntu-latest"]
+        host-os: ["ubuntu-latest", "windows-latest"]
         include:
           - php-versions: "7.3"
             experimental: false
             host-os: "ubuntu-18.04"
-          - php-versions: "8.1"
-            experimental: true
-            host-os: "ubuntu-latest"
+          - php-versions: "7.3"
+            experimental: false
+            host-os: "windows-latest"
 
     name: PHP ${{ matrix.php-versions }}
     steps:
@@ -36,23 +36,29 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: none
+          extensions: sockets, intl
 
       - name: Get composer cache directory
         id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
+      - name: Check codestyle
+        run: composer check
+
       - name: Run test suite
-        run: composer test
+        run: composer phpunit
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         php-versions: ["7.4", "8.0", "8.1"]
         host-os: ["ubuntu-latest", "windows-latest"]
+        experimental: [false]
         include:
           - php-versions: "7.3"
             experimental: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,18 +15,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.0"]
-        host-os: ["windows-latest"]
-        experimental: [false]
-#        php-versions: ["7.4", "8.0", "8.1"]
-#        host-os: ["ubuntu-latest", "windows-latest"]
-#        include:
-#          - php-versions: "7.3"
-#            experimental: false
-#            host-os: "ubuntu-18.04"
-#          - php-versions: "7.3"
-#            experimental: false
-#            host-os: "windows-latest"
+        php-versions: ["7.4", "8.0", "8.1"]
+        host-os: ["ubuntu-latest", "windows-latest"]
+        include:
+          - php-versions: "7.3"
+            experimental: false
+            host-os: "ubuntu-18.04"
+          - php-versions: "7.3"
+            experimental: false
+            host-os: "windows-latest"
 
     name: PHP ${{ matrix.php-versions }} - OS ${{ matrix.host-os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ $bag->addFile('../README.md', 'data/documentation/myreadme.md');
 // Add another algorithm
 $bag->addAlgorithm('sha1');
 
+// Get the algorithms
+$algos = $bag->getAlgorithms();
+var_dump($algos); // array(
+                  //   'sha512',
+                  //   'sha1',
+                  // )
+
 // Add a fetch url
 $bag->addFetchFile('http://www.google.ca', 'data/mywebsite.html');
 
@@ -125,10 +132,35 @@ if ($bag->hasBagInfoTag('contact-name')) {
 
     // Remove a specific tag value using array index from the above listing.
     $bag->removeBagInfoTagIndex('contact-name', 1); 
-    
+
+    // Get tags
+    $tags = $bag->getBagInfoByTag('contact-name');
+
+    var_dump($tags); // array(
+                     //    'Jared Whiklo',
+                     // )
+
+    $bag->addBagInfoTag('Contact-NAME', 'Bob Saget');
     // Get tags
     $tags = $bag->getBagInfoByTag('contact-name');
     
+    var_dump($tags); // array(
+                     //    'Jared Whiklo',
+                     //    'Bob Saget',
+                     // )
+    // Without the case sensitive flag as true, you must be exact.
+    $bag->removeBagInfoTagValue('contact-name', 'bob saget');
+    $tags = $bag->getBagInfoByTag('contact-name');
+
+    var_dump($tags); // array(
+                     //    'Jared Whiklo',
+                     //    'Bob Saget',
+                     // )
+
+    // With the case sensitive flag set to false, you can be less careful
+    $bag->removeBagInfoTagValue('contact-name', 'bob saget', false);
+    $tags = $bag->getBagInfoByTag('contact-name');
+
     var_dump($tags); // array(
                      //    'Jared Whiklo',
                      // )

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
       "./vendor/bin/phpcpd --suffix='.php' src"
     ],
     "phpunit": [
-      "phpdbg -qrr ./vendor/bin/phpunit --debug"
+      "phpdbg -qrr ./vendor/bin/phpunit --verbose --debug --testsuite BagIt"
     ],
     "test": [
       "@check",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
       "./vendor/bin/phpcpd --suffix='.php' src"
     ],
     "phpunit": [
-      "phpdbg -qrr ./vendor/bin/phpunit --verbose --debug --testsuite BagIt"
+      "phpdbg -qrr ./vendor/bin/phpunit --testsuite BagIt"
     ],
     "test": [
       "@check",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",
-    "phpdocumentor/phpdocumentor": "^3.0",
     "sebastian/phpcpd": "^6.0",
     "squizlabs/php_codesniffer": "^3.5",
     "donatj/mock-webserver": "^2.1",
@@ -51,7 +50,7 @@
       "./vendor/bin/phpcpd --suffix='.php' src"
     ],
     "phpunit": [
-      "phpdbg -qrr ./vendor/bin/phpunit"
+      "phpdbg -qrr ./vendor/bin/phpunit --debug"
     ],
     "test": [
       "@check",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,7 @@
     <testsuite name="BagIt-Windows">
       <directory suffix=".php">./tests</directory>
       <exclude>./tests/BagItTestFramework.php</exclude>
+      <exclude>./tests/FetchTest.php</exclude>
     </testsuite>
   </testsuites>
   <logging/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,9 +18,16 @@
       <clover outputFile="clover.xml"/>
     </report>
   </coverage>
-  <testsuite name="Bagit">
-    <directory suffix=".php">./tests</directory>
-    <exclude>./tests/BagItTestFramework.php</exclude>
-  </testsuite>
+  <testsuites>
+    <testsuite name="BagIt">
+      <directory suffix=".php">./tests</directory>
+      <exclude>./tests/BagItTestFramework.php</exclude>
+    </testsuite>
+    <testsuite name="BagIt-Windows">
+      <directory suffix=".php">./tests</directory>
+      <exclude>./tests/BagItTestFramework.php</exclude>
+      <exclude>./tests/FetchTest.php</exclude>
+    </testsuite>
+  </testsuites>
   <logging/>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,7 +26,6 @@
     <testsuite name="BagIt-Windows">
       <directory suffix=".php">./tests</directory>
       <exclude>./tests/BagItTestFramework.php</exclude>
-      <exclude>./tests/FetchTest.php</exclude>
     </testsuite>
   </testsuites>
   <logging/>

--- a/src/Bag.php
+++ b/src/Bag.php
@@ -514,7 +514,7 @@ class Bag
      * @param  string $dest
      *   The name of the file in the bag.
      * @throws \whikloj\BagItTools\Exceptions\BagItException
-     *   Source file does not exist or the destination is outside the data directory.
+     *   Generated source file does not exist or the destination is outside the data directory. Should not occur.
      * @throws \whikloj\BagItTools\Exceptions\FilesystemException
      *   Issues creating/deleting temporary file.
      */
@@ -1198,13 +1198,7 @@ class Bag
         $parentPath = dirname($path);
         if (substr($this->makeRelative($parentPath), 0, 5) == "data/") {
             $files = scandir($parentPath);
-            $payload = array_filter(
-                $files,
-                function ($o) {
-                    // Don't count directory specifiers.
-                    return (!BagUtils::isDotDir($o));
-                }
-            );
+            $payload = array_diff($files, [".", ".."]);
             if (count($payload) == 0) {
                 rmdir($parentPath);
             }
@@ -2210,13 +2204,10 @@ class Bag
      */
     private static function getDirectory(string $filepath): string
     {
-        $files = scandir($filepath);
+        $files = array_diff(scandir($filepath), [".", ".."]);
         $dirs = [];
         if (count($files) > 0) {
             foreach ($files as $file) {
-                if (BagUtils::isDotDir($file)) {
-                    continue;
-                }
                 $fullpath = $filepath . DIRECTORY_SEPARATOR . $file;
                 if (is_dir($fullpath)) {
                     $dirs[] = $fullpath;

--- a/src/Bag.php
+++ b/src/Bag.php
@@ -286,8 +286,8 @@ class Bag
             $this->validHashAlgorithms,
             array($this, 'normalizeHashAlgorithmName')
         );
-        $this->bagRoot = BagUtils::standardizePathSeparators($rootPath);
-        $this->bagRoot = BagUtils::getAbsolute($this->bagRoot, true);
+        $rootPath = BagUtils::standardizePathSeparators($rootPath);
+        $this->bagRoot = BagUtils::getAbsolute($rootPath, true);
         $this->loaded = (!$new);
         if ($new) {
             $this->createNewBag();

--- a/src/Bag.php
+++ b/src/Bag.php
@@ -286,8 +286,8 @@ class Bag
             $this->validHashAlgorithms,
             array($this, 'normalizeHashAlgorithmName')
         );
-        $this->bagRoot = $this->internalPath($rootPath);
-        $this->bagRoot = $this->internalPath(BagUtils::getAbsolute($this->bagRoot, true));
+        $this->bagRoot = BagUtils::standardizePathSeparators($rootPath);
+        $this->bagRoot = BagUtils::getAbsolute($this->bagRoot, true);
         $this->loaded = (!$new);
         if ($new) {
             $this->createNewBag();
@@ -542,15 +542,15 @@ class Bag
     public function makeAbsolute(string $path): string
     {
         $length = strlen(trim($this->bagRoot));
-        $path = $this->internalPath(BagUtils::getAbsolute($path));
+        $path = BagUtils::getAbsolute($path);
         if (substr($path, 0, $length) === $this->bagRoot) {
-            return mb_ereg_replace('\\\\|/', DIRECTORY_SEPARATOR, $path);
+            return $path;
         }
         $components = array_filter(explode("/", $path));
         $rootComponents = array_filter(explode("/", $this->bagRoot));
         $components = array_merge($rootComponents, $components);
-        $prefix = (preg_match('/^[a-z]:/i', $rootComponents[0] ?? '', $matches) ? '' : DIRECTORY_SEPARATOR);
-        return $prefix . implode(DIRECTORY_SEPARATOR, $components);
+        $prefix = (preg_match('/^[a-z]:/i', $rootComponents[0] ?? '', $matches) ? '' : '/');
+        return $prefix . implode('/', $components);
     }
 
     /**
@@ -563,7 +563,7 @@ class Bag
      */
     public function makeRelative(string $path): string
     {
-        $path = $this->internalPath(BagUtils::getAbsolute($path));
+        $path = BagUtils::getAbsolute($path);
         $rootLength = strlen($this->bagRoot);
         if (substr($path, 0, $rootLength) !== $this->bagRoot) {
             // We are not in bag root so return nothing.
@@ -826,7 +826,7 @@ class Bag
     public function hasAlgorithm(string $hashAlgorithm): bool
     {
         $internal_name = $this->getHashName($hashAlgorithm);
-        return $this->hashIsSupported($internal_name) ? $this->hasHash($internal_name) : false;
+        return $this->hashIsSupported($internal_name) && $this->hasHash($internal_name);
     }
 
     /**
@@ -1277,7 +1277,7 @@ class Bag
         if (file_exists($root)) {
             throw new BagItException("New bag directory $root exists");
         }
-        BagUtils::checkedMkdir($root . DIRECTORY_SEPARATOR . "data", 0777, true);
+        BagUtils::checkedMkdir($root . "/data", 0777, true);
         $this->updateBagIt();
         $this->payloadManifests = [
             self::DEFAULT_HASH_ALGORITHM => new PayloadManifest($this, self::DEFAULT_HASH_ALGORITHM)
@@ -1639,7 +1639,7 @@ class Bag
     private function loadTagManifests(): bool
     {
         $tagManifests = [];
-        $pattern = $this->getBagRoot() . DIRECTORY_SEPARATOR . "tagmanifest-*.txt";
+        $pattern = $this->getBagRoot() . "/tagmanifest-*.txt";
         $files = BagUtils::findAllByPattern($pattern);
         if (count($files) < 1) {
             return false;
@@ -1701,7 +1701,7 @@ class Bag
      */
     private function clearTagManifests(): void
     {
-        $pattern = $this->getBagRoot() . DIRECTORY_SEPARATOR . "tagmanifest-*.txt";
+        $pattern = $this->getBagRoot() . "/tagmanifest-*.txt";
         $this->clearFilesOfPattern($pattern);
         unset($this->tagManifests);
     }
@@ -1754,7 +1754,7 @@ class Bag
      */
     private function loadPayloadManifests(): void
     {
-        $pattern = $this->getBagRoot() . DIRECTORY_SEPARATOR . "manifest-*.txt";
+        $pattern = $this->getBagRoot() . "/manifest-*.txt";
         $manifests = BagUtils::findAllByPattern($pattern);
         if (count($manifests) == 0) {
             $this->addBagError('manifest-ALG.txt', 'No payload manifest files found.');
@@ -1815,7 +1815,7 @@ class Bag
      */
     private function clearPayloadManifests(): void
     {
-        $pattern = $this->getBagRoot() . DIRECTORY_SEPARATOR . "manifest-*.txt";
+        $pattern = $this->getBagRoot() . "/manifest-*.txt";
         $this->clearFilesOfPattern($pattern);
     }
 
@@ -2208,7 +2208,7 @@ class Bag
         $dirs = [];
         if (count($files) > 0) {
             foreach ($files as $file) {
-                $fullpath = $filepath . DIRECTORY_SEPARATOR . $file;
+                $fullpath = $filepath . '/' . $file;
                 if (is_dir($fullpath)) {
                     $dirs[] = $fullpath;
                 }
@@ -2271,19 +2271,6 @@ class Bag
             'file' => $filename,
             'message' => $message
         ];
-    }
-
-    /**
-     * Convert paths from using the OS directory separator to using /.
-     *
-     * @param  string $path
-     *   The external path.
-     * @return string
-     *   The modified path.
-     */
-    private function internalPath(string $path): string
-    {
-        return str_replace(DIRECTORY_SEPARATOR, "/", $path);
     }
 
     /**

--- a/src/BagUtils.php
+++ b/src/BagUtils.php
@@ -57,19 +57,6 @@ class BagUtils
     }
 
     /**
-     * Utility to test a filename as . or ..
-     *
-     * @param string $filename
-     *    Basename of a file or directory.
-     * @return bool
-     *    True if it is a dot directory name.
-     */
-    public static function isDotDir(string $filename): bool
-    {
-        return ($filename == "." || $filename == "..");
-    }
-
-    /**
      * Rebase the path in the data directory as payloads only deal in there.
      *
      * @param string $path
@@ -217,11 +204,8 @@ class BagUtils
         $found_files = [];
 
         while ($currentPath = array_shift($paths)) {
-            $files = scandir($currentPath);
+            $files = array_diff(scandir($currentPath), [".", ".."]);
             foreach ($files as $file) {
-                if (self::isDotDir($file)) {
-                    continue;
-                }
                 $fullPath = $currentPath . DIRECTORY_SEPARATOR . $file;
                 if (is_dir($fullPath) && !in_array($file, $exclusions)) {
                     $paths[] = $fullPath;

--- a/src/BagUtils.php
+++ b/src/BagUtils.php
@@ -299,7 +299,7 @@ class BagUtils
             throw new FilesystemException("Unable to create a temporary file with directory $directory, prefix" .
             " $prefix");
         }
-        return $res;
+        return self::standardizePathSeparators($res);
     }
 
     /**

--- a/src/BagUtils.php
+++ b/src/BagUtils.php
@@ -408,7 +408,6 @@ class BagUtils
      */
     public static function standardizePathSeparators(string $path): string
     {
-        // Cleaning path regarding OS
         return str_replace('\\', '/', $path);
     }
 }

--- a/src/BagUtils.php
+++ b/src/BagUtils.php
@@ -118,10 +118,9 @@ class BagUtils
      */
     public static function getAbsolute(string $path, bool $add_absolute = false): string
     {
-        // Cleaning path regarding OS
-        $path = mb_ereg_replace('\\\\|/', DIRECTORY_SEPARATOR, $path);
+        $path = self::standardizePathSeparators($path);
         // Check if path start with a separator (UNIX)
-        $startWithSeparator = substr($path, 0, 1) === DIRECTORY_SEPARATOR;
+        $startWithSeparator = substr($path, 0, 1) === '/';
         // Check if start with drive letter
         preg_match('/^[a-z]:/i', $path, $matches);
         $startWithLetterDir = $matches[0] ?? false;
@@ -134,12 +133,12 @@ class BagUtils
         if (!($startWithLetterDir || $startWithSeparator) && $add_absolute) {
             // This was relative to start with, prepend the current working directory.
             $current_dir = getcwd();
-            return BagUtils::getAbsolute(rtrim($current_dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR .
-                ltrim($path, DIRECTORY_SEPARATOR));
+            return BagUtils::getAbsolute(rtrim($current_dir, '/') . '/' .
+                ltrim($path, '/'));
         }
 
         // Get and filter empty sub paths
-        $subPaths = array_filter(explode(DIRECTORY_SEPARATOR, $path), 'mb_strlen');
+        $subPaths = array_filter(explode('/', $path), 'mb_strlen');
 
         $absolutes = [];
         foreach ($subPaths as $subPath) {
@@ -167,25 +166,10 @@ class BagUtils
                 $absolutes[] = $subPath;
             }
         }
-        $prefix = ($startWithSeparator ? DIRECTORY_SEPARATOR : $startWithLetterDir)
-            ? $startWithLetterDir . DIRECTORY_SEPARATOR
+        $prefix = ($startWithSeparator ? '/' : $startWithLetterDir)
+            ? $startWithLetterDir . '/'
             : "";
-        return $prefix . implode(DIRECTORY_SEPARATOR, $absolutes);
-    }
-
-    /**
-     * Paths for new and existing files should not have these conditions.
-     *
-     * @param string $path
-     *   The relative path from an existing bag file or as a destination for a new file.
-     * @return bool
-     *   True if invalid characters/character sequences exist.
-     */
-    public static function invalidPathCharacters(string $path): bool
-    {
-        $path = urldecode($path);
-        return (in_array($path[0] ?? '', ['/', '\\']) || strpos($path, "~") !== false ||
-            substr($path, 0, 3) == "../");
+        return $prefix . implode('/', $absolutes);
     }
 
     /**
@@ -206,7 +190,7 @@ class BagUtils
         while ($currentPath = array_shift($paths)) {
             $files = array_diff(scandir($currentPath), [".", ".."]);
             foreach ($files as $file) {
-                $fullPath = $currentPath . DIRECTORY_SEPARATOR . $file;
+                $fullPath = $currentPath . '/' . $file;
                 if (is_dir($fullPath) && !in_array($file, $exclusions)) {
                     $paths[] = $fullPath;
                 } elseif (is_file($fullPath)) {
@@ -412,5 +396,19 @@ class BagUtils
     public static function splitFileDataOnLineEndings(string $data): array
     {
         return preg_split("/(\r\n|\r|\n)/", $data);
+    }
+
+    /**
+     * Try using only forward slashes internally to avoid the extraneous checks for \ and or /
+     *
+     * @param string $path
+     *   The original path.
+     * @return string
+     *   The corrected path using /
+     */
+    public static function standardizePathSeparators(string $path): string
+    {
+        // Cleaning path regarding OS
+        return str_replace('\\', '/', $path);
     }
 }

--- a/src/Commands/ValidateCommand.php
+++ b/src/Commands/ValidateCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use whikloj\BagItTools\Bag;
+use whikloj\BagItTools\BagUtils;
 use whikloj\BagItTools\Exceptions\BagItException;
 
 /**
@@ -40,9 +41,9 @@ class ValidateCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $path = mb_ereg_replace('\\\\|/', DIRECTORY_SEPARATOR, $input->getArgument('bag-path'));
-        if (($path[0] ?? "") !== DIRECTORY_SEPARATOR && !preg_match("/^[a-z]:/i", $path)) {
-            $path = getcwd() . DIRECTORY_SEPARATOR . $path;
+        $path = BagUtils::standardizePathSeparators($input->getArgument('bag-path'));
+        if (($path[0] ?? "") !== '/' && !preg_match("/^[a-z]:/i", $path)) {
+            $path = getcwd() . '/' . $path;
             $realpath = realpath($path);
         }
         if ((isset($realpath) && $realpath === false) || !file_exists($path)) {

--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -602,11 +602,7 @@ class Fetch
      */
     private function urlExistsInFile(string $url): bool
     {
-        $uris = array_column($this->files, 'uri');
-        array_walk($uris, function (&$item) {
-            $item = strtolower($item);
-        });
-        return (in_array(strtolower($url), $uris));
+        return $this->existsInFile($url, 'uri');
     }
 
     /**
@@ -619,11 +615,24 @@ class Fetch
      */
     private function destinationExistsInFile(string $dest): bool
     {
-        $paths = array_column($this->files, 'destination');
-        array_walk($paths, function (&$item) {
-            $item = strtolower($item);
-        });
-        return (in_array(strtolower($dest), $paths));
+        return $this->existsInFile($dest, 'destination');
+    }
+
+    /**
+     * Check multi-dimensional array for a specific value in a specific field.
+     *
+     * @param string $arg
+     *   The value to look for.
+     * @param string $key
+     *   The key in the $this->files array to check in.
+     * @return bool
+     *   True if the value is located in the specified field.
+     */
+    private function existsInFile(string $arg, string $key): bool
+    {
+        $values = array_column($this->files, $key);
+        $values = array_map('strtolower', $values);
+        return (in_array(strtolower($arg), $values));
     }
 
     /**

--- a/tests/BagInternalTest.php
+++ b/tests/BagInternalTest.php
@@ -38,13 +38,13 @@ class BagInternalTest extends BagItTestFramework
         ];
 
         foreach ($valid_paths as $path => $expected) {
-            $fullpath = $baseDir . DIRECTORY_SEPARATOR . $path;
+            $fullpath = $baseDir . '/' . $path;
             $relative = $bag->makeRelative($fullpath);
             $this->assertEquals($expected, $relative);
         }
 
         foreach ($invalid_paths as $path) {
-            $fullpath = $baseDir . DIRECTORY_SEPARATOR . $path;
+            $fullpath = $baseDir . '/' . $path;
             $relative = $bag->makeRelative($fullpath);
             $this->assertEquals('', $relative);
         }
@@ -73,15 +73,15 @@ class BagInternalTest extends BagItTestFramework
         ];
 
         foreach ($valid_paths as $path => $expected) {
-            $fullpath = mb_ereg_replace('\\\\|/', DIRECTORY_SEPARATOR, $baseDir . DIRECTORY_SEPARATOR . $expected);
+            $fullpath = str_replace('\\', '/', $baseDir . '/' . $expected);
             $absolute = $bag->makeAbsolute($path);
             $this->assertEquals($fullpath, $absolute);
         }
 
-        // There are no invalid paths as makeAbsolute only promises to prepend bagRoot + DIRECTORY_SEPARATOR to the
+        // There are no invalid paths as makeAbsolute only promises to prepend bagRoot + / to the
         // incoming value once normalized.
         foreach ($invalid_paths as $expected) {
-            $fullpath = mb_ereg_replace('\\\\|/', DIRECTORY_SEPARATOR, $baseDir . DIRECTORY_SEPARATOR . $expected);
+            $fullpath = str_replace('\\', '/', $baseDir . '/' . $expected);
             $absolute = $bag->makeAbsolute($fullpath);
             $this->assertEquals($fullpath, $absolute);
         }
@@ -184,10 +184,10 @@ class BagInternalTest extends BagItTestFramework
      */
     public function testResetErrorsAndWarnings(): void
     {
-        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'Test097Bag');
+        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . '/Test097Bag');
         $bag = Bag::load($this->tmpdir);
         $this->assertEquals('0.97', $bag->getVersionString());
-        touch($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'oops.txt');
+        touch($bag->getDataDirectory() . '/oops.txt');
         $this->assertFalse($bag->isValid());
         $this->assertCount(1, $bag->getErrors());
         $this->assertCount(2, $bag->getWarnings());

--- a/tests/BagItTestFramework.php
+++ b/tests/BagItTestFramework.php
@@ -121,11 +121,8 @@ class BagItTestFramework extends TestCase
     protected static function deleteDirAndContents(string $path): void
     {
         if (is_dir($path)) {
-            $files = scandir($path);
+            $files = array_diff(scandir($path), [".", ".."]);
             foreach ($files as $file) {
-                if (BagUtils::isDotDir($file)) {
-                    continue;
-                }
                 $currentFile = $path . DIRECTORY_SEPARATOR . $file;
                 if (is_dir($currentFile)) {
                     self::deleteDirAndContents($currentFile);
@@ -198,10 +195,8 @@ class BagItTestFramework extends TestCase
      */
     private static function copyDir(string $src, string $dest): void
     {
-        foreach (scandir($src) as $item) {
-            if (BagUtils::isDotDir($item)) {
-                continue;
-            }
+        $files = array_diff(scandir($src), [".", ".."]);
+        foreach ($files as $item) {
             if (is_dir("$src/$item")) {
                 if (!is_dir("$dest/$item")) {
                     mkdir("$dest/$item");

--- a/tests/BagItTestFramework.php
+++ b/tests/BagItTestFramework.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
 use whikloj\BagItTools\Bag;
-use whikloj\BagItTools\BagUtils;
 use whikloj\BagItTools\Exceptions\FilesystemException;
 
 /**
@@ -20,29 +19,28 @@ class BagItTestFramework extends TestCase
     /**
      * Path to the test resources directory.
      */
-    protected const TEST_RESOURCES = __DIR__ . DIRECTORY_SEPARATOR . "resources";
+    protected const TEST_RESOURCES = __DIR__ . "/resources";
 
     /**
      * Location of the Test Bag
      */
-    protected const TEST_BAG_DIR = self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "TestBag";
+    protected const TEST_BAG_DIR = self::TEST_RESOURCES . "/TestBag";
 
     /**
      * Location of the Test Bag
      */
-    protected const TEST_EXTENDED_BAG_DIR = self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "TestExtendedBag";
+    protected const TEST_EXTENDED_BAG_DIR = self::TEST_RESOURCES . "/TestExtendedBag";
 
     /**
      * Location of manifests.
      */
-    protected const TEST_MANIFEST_DIR = self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "manifests";
+    protected const TEST_MANIFEST_DIR = self::TEST_RESOURCES . "/manifests";
 
     /**
      * Location and hashes of the test image.
      */
     protected const TEST_IMAGE = [
-        'filename' => self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "images" . DIRECTORY_SEPARATOR .
-            "scenic-landscape.jpg",
+        'filename' => self::TEST_RESOURCES . "/images/" . "scenic-landscape.jpg",
         'checksums' => [
             'md5' => 'f181491b485c45ecaefdc3393da4aea6',
             'sha1' => '0cc9a4a7e02edf70650a5a8bb972224657bb48bb',
@@ -56,7 +54,7 @@ class BagItTestFramework extends TestCase
      * Location and hashes of a test text file.
      */
     protected const TEST_TEXT = [
-        'filename' => self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "text" . DIRECTORY_SEPARATOR . "empty.txt",
+        'filename' => self::TEST_RESOURCES . "/text/empty.txt",
         'checksums' => [
             'md5' => 'd41d8cd98f00b204e9800998ecf8427e',
             'sha1' => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
@@ -123,7 +121,7 @@ class BagItTestFramework extends TestCase
         if (is_dir($path)) {
             $files = array_diff(scandir($path), [".", ".."]);
             foreach ($files as $file) {
-                $currentFile = $path . DIRECTORY_SEPARATOR . $file;
+                $currentFile = $path . '/' . $file;
                 if (is_dir($currentFile)) {
                     self::deleteDirAndContents($currentFile);
                 } elseif (is_file($currentFile)) {
@@ -276,7 +274,7 @@ class BagItTestFramework extends TestCase
 
         $expected = sprintf($template, $use_version, $use_encoding);
 
-        $bagit_file = $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bagit.txt';
+        $bagit_file = $bag->getBagRoot() . '/bagit.txt';
         $this->assertFileExists($bagit_file);
         $contents = file_get_contents($bagit_file);
         $this->assertEquals($expected, $contents);

--- a/tests/BagItTestFramework.php
+++ b/tests/BagItTestFramework.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
 use whikloj\BagItTools\Bag;
+use whikloj\BagItTools\BagUtils;
 use whikloj\BagItTools\Exceptions\FilesystemException;
 
 /**
@@ -104,7 +105,7 @@ class BagItTestFramework extends TestCase
         $tempname = tempnam("", "bagit_");
         if ($tempname !== false) {
             if (unlink($tempname)) {
-                return $tempname;
+                return BagUtils::standardizePathSeparators($tempname);
             }
         }
         throw new FilesystemException("Unable to create temporary directory");

--- a/tests/BagItTestFramework.php
+++ b/tests/BagItTestFramework.php
@@ -291,7 +291,7 @@ class BagItTestFramework extends TestCase
      */
     protected function assertStringContainsStringWithoutNewlines(string $expected, string $original): void
     {
-        $split_original = explode("\n", $original);
+        $split_original = preg_split("/(\r\n|\r|\r)/", $original);
         array_walk($split_original, function (&$o) {
             $o = trim($o);
         });

--- a/tests/BagItTestFramework.php
+++ b/tests/BagItTestFramework.php
@@ -291,7 +291,7 @@ class BagItTestFramework extends TestCase
      */
     protected function assertStringContainsStringWithoutNewlines(string $expected, string $original): void
     {
-        $split_original = preg_split("/(\r\n|\r|\r)/", $original);
+        $split_original = preg_split("/(\r\n|\r|\n)/", $original);
         array_walk($split_original, function (&$o) {
             $o = trim($o);
         });

--- a/tests/BagTest.php
+++ b/tests/BagTest.php
@@ -25,10 +25,10 @@ class BagTest extends BagItTestFramework
     {
         $this->assertFileDoesNotExist($this->tmpdir);
         $bag = Bag::create($this->tmpdir);
-        $this->assertFileExists($this->tmpdir . DIRECTORY_SEPARATOR . "bagit.txt");
-        $this->assertTrue(is_file($this->tmpdir . DIRECTORY_SEPARATOR . "bagit.txt"));
-        $this->assertFileExists($this->tmpdir . DIRECTORY_SEPARATOR . "data");
-        $this->assertTrue(is_dir($this->tmpdir . DIRECTORY_SEPARATOR . "data"));
+        $this->assertFileExists($this->tmpdir . "/bagit.txt");
+        $this->assertTrue(is_file($this->tmpdir . "/bagit.txt"));
+        $this->assertFileExists($this->tmpdir . "/data");
+        $this->assertTrue(is_dir($this->tmpdir . "/data"));
         $this->assertTrue($bag->isValid());
     }
 
@@ -55,7 +55,7 @@ class BagTest extends BagItTestFramework
     public function testCreateBagRelative(): void
     {
         mkdir($this->tmpdir);
-        $newDir = $this->tmpdir . DIRECTORY_SEPARATOR . "some-new-dir";
+        $newDir = $this->tmpdir . "/some-new-dir";
         $this->assertDirectoryDoesNotExist($newDir);
         $curr = getcwd();
         chdir($this->tmpdir);
@@ -73,7 +73,7 @@ class BagTest extends BagItTestFramework
     public function testCreateBagRelative2(): void
     {
         mkdir($this->tmpdir);
-        $newDir = $this->tmpdir . DIRECTORY_SEPARATOR . "some-new-dir";
+        $newDir = $this->tmpdir . "/some-new-dir";
         $this->assertDirectoryDoesNotExist($newDir);
         $curr = getcwd();
         chdir($this->tmpdir);
@@ -122,7 +122,7 @@ class BagTest extends BagItTestFramework
             $bag->getVersion()
         );
         file_put_contents(
-            $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bagit.txt',
+            $bag->getBagRoot() . '/bagit.txt',
             "BagIt-Version: 0.97" . PHP_EOL . "Tag-File-Character-Encoding: UTF-8" . PHP_EOL
         );
         $newbag = Bag::load($this->tmpdir);
@@ -142,7 +142,7 @@ class BagTest extends BagItTestFramework
     {
         $bag = Bag::create($this->tmpdir);
         $this->assertEquals($this->tmpdir, $bag->getBagRoot());
-        $data = $this->tmpdir . DIRECTORY_SEPARATOR . 'data';
+        $data = $this->tmpdir . '/data';
         $this->assertEquals($data, $bag->getDataDirectory());
     }
 
@@ -156,10 +156,8 @@ class BagTest extends BagItTestFramework
         $source_file = self::TEST_IMAGE['filename'];
         $bag = Bag::create($this->tmpdir);
         $bag->addFile($source_file, "some/image.txt");
-        $this->assertDirectoryExists($bag->getDataDirectory() .
-        DIRECTORY_SEPARATOR . 'some');
-        $this->assertFileExists($bag->getDataDirectory() .
-        DIRECTORY_SEPARATOR . 'some' . DIRECTORY_SEPARATOR . 'image.txt');
+        $this->assertDirectoryExists($bag->getDataDirectory() . '/some');
+        $this->assertFileExists($bag->getDataDirectory() . '/some/image.txt');
     }
 
     /**
@@ -207,10 +205,8 @@ class BagTest extends BagItTestFramework
 
         $bag = Bag::create($this->tmpdir);
         $bag->addFile($source_file, $destination);
-        $this->assertDirectoryExists($bag->getDataDirectory() .
-            DIRECTORY_SEPARATOR . 'some');
-        $this->assertFileExists($bag->getDataDirectory() .
-            DIRECTORY_SEPARATOR . 'some' . DIRECTORY_SEPARATOR . 'image.txt');
+        $this->assertDirectoryExists($bag->getDataDirectory() . '/some');
+        $this->assertFileExists($bag->getDataDirectory() . '/some/image.txt');
 
         $this->expectException(BagItException::class);
         $this->expectExceptionMessage("File data/$destination already exists in the bag.");
@@ -227,9 +223,9 @@ class BagTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareBasicTestBag();
         $bag = Bag::load($this->tmpdir);
-        $this->assertFileExists($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'jekyll_and_hyde.txt');
+        $this->assertFileExists($bag->getDataDirectory() . '/jekyll_and_hyde.txt');
         $bag->removeFile('jekyll_and_hyde.txt');
-        $this->assertFileDoesNotExist($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'jekyll_and_hyde.txt');
+        $this->assertFileDoesNotExist($bag->getDataDirectory() . '/jekyll_and_hyde.txt');
     }
 
     /**
@@ -242,17 +238,12 @@ class BagTest extends BagItTestFramework
     {
         $source = "Hi this is a test";
         $bag = Bag::create($this->tmpdir);
-        $this->assertDirectoryDoesNotExist($bag->getDataDirectory() .
-            DIRECTORY_SEPARATOR . 'some');
-        $this->assertFileDoesNotExist($bag->getDataDirectory() .
-            DIRECTORY_SEPARATOR . 'some' . DIRECTORY_SEPARATOR . 'text.txt');
+        $this->assertDirectoryDoesNotExist($bag->getDataDirectory() . '/some');
+        $this->assertFileDoesNotExist($bag->getDataDirectory() . '/some/text.txt');
         $bag->createFile($source, "some/text.txt");
-        $this->assertDirectoryExists($bag->getDataDirectory() .
-            DIRECTORY_SEPARATOR . 'some');
-        $this->assertFileExists($bag->getDataDirectory() .
-            DIRECTORY_SEPARATOR . 'some' . DIRECTORY_SEPARATOR . 'text.txt');
-        $contents = file_get_contents($bag->getDataDirectory() .
-            DIRECTORY_SEPARATOR . 'some' . DIRECTORY_SEPARATOR . 'text.txt');
+        $this->assertDirectoryExists($bag->getDataDirectory() . '/some');
+        $this->assertFileExists($bag->getDataDirectory() . '/some/text.txt');
+        $contents = file_get_contents($bag->getDataDirectory() . '/some/text.txt');
         $this->assertEquals($source, $contents);
     }
 
@@ -268,8 +259,7 @@ class BagTest extends BagItTestFramework
         $destination = "some/text.txt";
         $bag = Bag::create($this->tmpdir);
         $bag->createFile($source, $destination);
-        $contents = file_get_contents($bag->getDataDirectory() .
-            DIRECTORY_SEPARATOR . 'some' . DIRECTORY_SEPARATOR . 'text.txt');
+        $contents = file_get_contents($bag->getDataDirectory() . '/some/text.txt');
         $this->assertEquals($source, $contents);
 
         $this->expectException(BagItException::class);
@@ -289,7 +279,7 @@ class BagTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareBasicTestBag();
 
-        $picturesDir = implode(DIRECTORY_SEPARATOR, [
+        $picturesDir = implode('/', [
             $this->tmpdir,
             'data',
             'pictures',
@@ -297,20 +287,20 @@ class BagTest extends BagItTestFramework
 
         $bag = Bag::load($this->tmpdir);
 
-        $this->assertFileExists($picturesDir . DIRECTORY_SEPARATOR . 'another_picture.txt');
-        $this->assertFileExists($picturesDir . DIRECTORY_SEPARATOR . 'some_more_data.txt');
+        $this->assertFileExists($picturesDir . '/another_picture.txt');
+        $this->assertFileExists($picturesDir . '/some_more_data.txt');
 
         // Don't reference the correct path.
         $bag->removeFile('some_more_data.txt');
-        $this->assertFileExists($picturesDir . DIRECTORY_SEPARATOR . 'some_more_data.txt');
+        $this->assertFileExists($picturesDir . '/some_more_data.txt');
 
         // Reference with data/ prefix
         $bag->removeFile('data/pictures/some_more_data.txt');
-        $this->assertFileDoesNotExist($picturesDir . DIRECTORY_SEPARATOR . 'some_more_data.txt');
+        $this->assertFileDoesNotExist($picturesDir . '/some_more_data.txt');
 
         // Reference without data/ prefix
         $bag->removeFile('pictures/another_picture.txt');
-        $this->assertFileDoesNotExist($picturesDir . DIRECTORY_SEPARATOR . 'another_picture.txt');
+        $this->assertFileDoesNotExist($picturesDir . '/another_picture.txt');
 
         // All files are gone so directory data/pictures should have been removed.
         $this->assertDirectoryDoesNotExist($picturesDir);
@@ -328,20 +318,20 @@ class BagTest extends BagItTestFramework
 
         $bag = Bag::load($this->tmpdir);
         // Directory doesn't exist.
-        $this->assertDirectoryDoesNotExist($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'empty');
+        $this->assertDirectoryDoesNotExist($bag->getDataDirectory() . '/empty');
         // Add files.
         $bag->addFile(self::TEST_IMAGE['filename'], 'data/empty/test.jpg');
         $bag->addFile(self::TEST_TEXT['filename'], 'data/empty/.hidden');
         // Directory does exist.
-        $this->assertDirectoryExists($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'empty');
+        $this->assertDirectoryExists($bag->getDataDirectory() . '/empty');
         // Remove the image but leave a hidden file.
         $bag->removeFile('data/empty/test.jpg');
         // Directory does exist.
-        $this->assertDirectoryExists($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'empty');
+        $this->assertDirectoryExists($bag->getDataDirectory() . '/empty');
         // Remove the hidden file.
         $bag->removeFile('data/empty/.hidden');
         // Directory is removed too.
-        $this->assertDirectoryDoesNotExist($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'empty');
+        $this->assertDirectoryDoesNotExist($bag->getDataDirectory() . '/empty');
     }
 
     /**
@@ -357,23 +347,23 @@ class BagTest extends BagItTestFramework
         $manifest = $bag->getPayloadManifests()['sha256'];
         // File doesn't exist.
         $this->assertArrayNotHasKey('data/land.jpg', $manifest->getHashes());
-        $this->assertFileDoesNotExist($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'land.jpg');
+        $this->assertFileDoesNotExist($bag->getDataDirectory() . '/land.jpg');
 
         // Add the file
         $bag->addFile(self::TEST_IMAGE['filename'], 'data/land.jpg');
         $manifest = $bag->getPayloadManifests()['sha256'];
         $this->assertArrayNotHasKey('data/land.jpg', $manifest->getHashes());
-        $this->assertFileExists($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'land.jpg');
+        $this->assertFileExists($bag->getDataDirectory() . '/land.jpg');
         // Update
         $bag->update();
         $manifest = $bag->getPayloadManifests()['sha256'];
         $this->assertArrayHasKey('data/land.jpg', $manifest->getHashes());
 
         // Remove it manually.
-        unlink($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'land.jpg');
+        unlink($bag->getDataDirectory() . '/land.jpg');
         $manifest = $bag->getPayloadManifests()['sha256'];
         // File is gone
-        $this->assertFileDoesNotExist($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'land.jpg');
+        $this->assertFileDoesNotExist($bag->getDataDirectory() . '/land.jpg');
         // Still exists in the manifest.
         $this->assertArrayHasKey('data/land.jpg', $manifest->getHashes());
         // Update BagIt files on disk.
@@ -641,7 +631,7 @@ class BagTest extends BagItTestFramework
      */
     public function testNonExistantCompressed(): void
     {
-        $path = DIRECTORY_SEPARATOR . 'my' . DIRECTORY_SEPARATOR . 'directory.tar';
+        $path = '/my/directory.tar';
 
         $this->expectException(BagItException::class);
         $this->expectExceptionMessage("Path $path does not exist, could not load Bag.");
@@ -661,15 +651,15 @@ class BagTest extends BagItTestFramework
      */
     public function testUncompressTarGz(): void
     {
-        $bag = Bag::load(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'testtar.tgz');
+        $bag = Bag::load(self::TEST_RESOURCES . '/testtar.tgz');
         $this->assertTrue($bag->isValid());
         $this->assertTrue($bag->hasAlgorithm('sha224'));
         $manifest = $bag->getPayloadManifests()['sha224'];
         foreach ($manifest->getHashes() as $path => $hash) {
-            $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . BagUtils::baseInData($path));
+            $this->assertFileExists($bag->getBagRoot() . '/' . BagUtils::baseInData($path));
         }
         $this->assertNotEquals(
-            self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'testtar.tgz',
+            self::TEST_RESOURCES . '/testtar.tgz',
             $bag->getBagRoot()
         );
     }
@@ -685,15 +675,15 @@ class BagTest extends BagItTestFramework
      */
     public function testUncompressTarBzip(): void
     {
-        $bag = Bag::load(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'testtar.tar.bz2');
+        $bag = Bag::load(self::TEST_RESOURCES . '/testtar.tar.bz2');
         $this->assertTrue($bag->isValid());
         $this->assertTrue($bag->hasAlgorithm('sha224'));
         $manifest = $bag->getPayloadManifests()['sha224'];
         foreach ($manifest->getHashes() as $path => $hash) {
-            $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . BagUtils::baseInData($path));
+            $this->assertFileExists($bag->getBagRoot() . '/' . BagUtils::baseInData($path));
         }
         $this->assertNotEquals(
-            self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'testtar.tar.bz2',
+            self::TEST_RESOURCES . '/testtar.tar.bz2',
             $bag->getBagRoot()
         );
     }
@@ -708,15 +698,15 @@ class BagTest extends BagItTestFramework
      */
     public function testUncompressZip(): void
     {
-        $bag = Bag::load(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'testzip.zip');
+        $bag = Bag::load(self::TEST_RESOURCES . '/testzip.zip');
         $this->assertTrue($bag->isValid());
         $this->assertTrue($bag->hasAlgorithm('sha224'));
         $manifest = $bag->getPayloadManifests()['sha224'];
         foreach ($manifest->getHashes() as $path => $hash) {
-            $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . BagUtils::baseInData($path));
+            $this->assertFileExists($bag->getBagRoot() . '/' . BagUtils::baseInData($path));
         }
         $this->assertNotEquals(
-            self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'testzip.zip',
+            self::TEST_RESOURCES . '/testzip.zip',
             $bag->getBagRoot()
         );
     }
@@ -866,11 +856,11 @@ class BagTest extends BagItTestFramework
         # Only spaces after the colon allowed.
         $v10_regex = "/^.*?\b:\s+\b.*?$/";
 
-        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'Test097Bag');
+        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . '/Test097Bag');
         $bag = Bag::load($this->tmpdir);
         $this->assertEquals('0.97', $bag->getVersionString());
         $this->assertTrue($bag->isValid());
-        $fp = fopen($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt', 'r');
+        $fp = fopen($bag->getBagRoot() . '/bag-info.txt', 'r');
         while (!feof($fp)) {
             $line = (string) fgets($fp);
             $line = trim($line);
@@ -884,7 +874,7 @@ class BagTest extends BagItTestFramework
         $bag->upgrade();
         $this->assertEquals('1.0', $bag->getVersionString());
         $this->assertTrue($bag->isValid());
-        $fp = fopen($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt', 'r');
+        $fp = fopen($bag->getBagRoot() . '/bag-info.txt', 'r');
         while (!feof($fp)) {
             $line = (string) fgets($fp);
             $line = trim($line);
@@ -939,10 +929,10 @@ class BagTest extends BagItTestFramework
         $this->expectException(BagItException::class);
         $this->expectExceptionMessage("This bag is not valid, we cannot automatically upgrade it.");
 
-        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'Test097Bag');
+        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . '/Test097Bag');
         $bag = Bag::load($this->tmpdir);
         $this->assertEquals('0.97', $bag->getVersionString());
-        touch($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'oops.txt');
+        touch($bag->getDataDirectory() . '/oops.txt');
         $this->assertFalse($bag->isValid());
         $bag->upgrade();
     }
@@ -969,7 +959,7 @@ class BagTest extends BagItTestFramework
     public function testBagItTooManyLines(): void
     {
         $this->tmpdir = $this->prepareBasicTestBag();
-        $fp = fopen($this->tmpdir . DIRECTORY_SEPARATOR . 'bagit.txt', 'a');
+        $fp = fopen($this->tmpdir . '/bagit.txt', 'a');
         fwrite($fp, "This is more stuff\n");
         fclose($fp);
         $bag = Bag::load($this->tmpdir);
@@ -984,7 +974,7 @@ class BagTest extends BagItTestFramework
     public function testBagItVersionLineInvalid(): void
     {
         $this->tmpdir = $this->prepareBasicTestBag();
-        $fp = fopen($this->tmpdir . DIRECTORY_SEPARATOR . 'bagit.txt', 'w');
+        $fp = fopen($this->tmpdir . '/bagit.txt', 'w');
         fwrite($fp, "BagIt-Version: M.N\nTag-File-Character-Encoding: UTF-8\n");
         fclose($fp);
         $bag = Bag::load($this->tmpdir);
@@ -999,7 +989,7 @@ class BagTest extends BagItTestFramework
     public function testBagItEncodingLineError(): void
     {
         $this->tmpdir = $this->prepareBasicTestBag();
-        $fp = fopen($this->tmpdir . DIRECTORY_SEPARATOR . 'bagit.txt', 'w');
+        $fp = fopen($this->tmpdir . '/bagit.txt', 'w');
         fwrite($fp, "BagIt-Version: 1.0\nTag-File-Encoding: UTF-8\n");
         fclose($fp);
         $bag = Bag::load($this->tmpdir);
@@ -1014,7 +1004,7 @@ class BagTest extends BagItTestFramework
     public function testFailOnEncodedBagIt(): void
     {
         $this->tmpdir = $this->prepareBasicTestBag();
-        $fp = fopen($this->tmpdir . DIRECTORY_SEPARATOR . 'bagit.txt', 'w');
+        $fp = fopen($this->tmpdir . '/bagit.txt', 'w');
         $encoded_string = mb_convert_encoding("BagIt-Version: 1.0\nTag-File-Encoding: UTF-8\n", "byte4le");
         fwrite($fp, $encoded_string);
         fclose($fp);
@@ -1046,7 +1036,7 @@ class BagTest extends BagItTestFramework
     {
         // Make the directory
         mkdir($this->tmpdir);
-        $fullpath = $this->tmpdir . DIRECTORY_SEPARATOR . "existing_bag";
+        $fullpath = $this->tmpdir . "/existing_bag";
         mkdir($fullpath);
 
         $this->expectException(BagItException::class);
@@ -1072,7 +1062,7 @@ class BagTest extends BagItTestFramework
         // Make the directory
         mkdir($this->tmpdir);
         $curr = getcwd();
-        $full_path = $this->tmpdir . DIRECTORY_SEPARATOR . "existing_bag";
+        $full_path = $this->tmpdir . "/existing_bag";
         chdir($this->tmpdir);
         $bag = Bag::create("existing_bag");
         $bagroot = $bag->getBagRoot();

--- a/tests/BagUtilsTest.php
+++ b/tests/BagUtilsTest.php
@@ -16,18 +16,6 @@ use whikloj\BagItTools\Exceptions\FilesystemException;
 class BagUtilsTest extends BagItTestFramework
 {
     /**
-     * @covers ::isDotDir
-     */
-    public function testIsDotDir(): void
-    {
-        $this->assertTrue(BagUtils::isDotDir('.'));
-        $this->assertTrue(BagUtils::isDotDir('..'));
-        $this->assertFalse(BagUtils::isDotDir('.hidden'));
-        $this->assertFalse(BagUtils::isDotDir('./upAdirectory'));
-        $this->assertFalse(BagUtils::isDotDir('random.file'));
-    }
-
-    /**
      * @covers ::baseInData
      */
     public function testBaseInData(): void

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -7,6 +7,7 @@ namespace whikloj\BagItTools\Test;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
+use whikloj\BagItTools\BagUtils;
 use whikloj\BagItTools\Commands\ValidateCommand;
 
 /**
@@ -36,7 +37,7 @@ class CommandTest extends BagItTestFramework
      */
     public function testValidateInvalidPath(): void
     {
-        $path = __DIR__ . '/DEVNULL';
+        $path = BagUtils::standardizePathSeparators(__DIR__) . '/DEVNULL';
         $this->commandTester->execute([
             'bag-path' => $path,
         ]);
@@ -50,7 +51,7 @@ class CommandTest extends BagItTestFramework
      */
     public function testValidBag(): void
     {
-        $path = __DIR__ . '/resources/TestBag';
+        $path = BagUtils::standardizePathSeparators(__DIR__) . '/resources/TestBag';
         $this->commandTester->execute([
             'bag-path' => $path,
         ]);

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -36,7 +36,7 @@ class CommandTest extends BagItTestFramework
      */
     public function testValidateInvalidPath(): void
     {
-        $path = __DIR__ . DIRECTORY_SEPARATOR . 'DEVNULL';
+        $path = __DIR__ . '/DEVNULL';
         $this->commandTester->execute([
             'bag-path' => $path,
         ]);
@@ -50,7 +50,7 @@ class CommandTest extends BagItTestFramework
      */
     public function testValidBag(): void
     {
-        $path = __DIR__ . DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . "TestBag";
+        $path = __DIR__ . '/resources/TestBag';
         $this->commandTester->execute([
             'bag-path' => $path,
         ]);
@@ -66,7 +66,7 @@ class CommandTest extends BagItTestFramework
     {
         $this->tmpdir = self::prepareBasicTestBag();
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . "bagit.txt",
+            $this->tmpdir . "/bagit.txt",
             "BagIt-Version: M.N\nTag-File-Character-Encoding:\n"
         );
         $this->commandTester->execute([
@@ -83,7 +83,7 @@ class CommandTest extends BagItTestFramework
     public function testInvalidWithErrors(): void
     {
         $this->tmpdir = self::prepareBasicTestBag();
-        unlink($this->tmpdir . DIRECTORY_SEPARATOR . "bagit.txt");
+        unlink($this->tmpdir . "/bagit.txt");
         $this->commandTester->execute([
             'bag-path' => $this->tmpdir,
         ], [
@@ -100,7 +100,7 @@ class CommandTest extends BagItTestFramework
      */
     public function testInvalidWithWarnings(): void
     {
-        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'Test097Bag');
+        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . '/Test097Bag');
         $this->commandTester->execute([
             'bag-path' => $this->tmpdir,
         ], [
@@ -124,11 +124,10 @@ class CommandTest extends BagItTestFramework
             'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
         ]);
         $output = $this->commandTester->getDisplay();
-        $ds = DIRECTORY_SEPARATOR;
         // Split this in two as we don't know what the actual root directory with be
         $this->assertStringContainsString("[ERROR] Path", $output);
         $this->assertStringContainsStringWithoutNewlines(
-            $ds . "subdirectory" . $ds . "to" . $ds . "bag does not exist, cannot validate.",
+            "/subdirectory/to/bag does not exist, cannot validate.",
             $output
         );
     }

--- a/tests/ExtendedBagTest.php
+++ b/tests/ExtendedBagTest.php
@@ -17,7 +17,7 @@ class ExtendedBagTest extends BagItTestFramework
     /**
      * @var string The directory to the bag-info files.
      */
-    private const BAG_INFO_DIR = self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "bag-infos";
+    private const BAG_INFO_DIR = self::TEST_RESOURCES . "/bag-infos";
 
     /**
      * @group Extended
@@ -54,16 +54,16 @@ class ExtendedBagTest extends BagItTestFramework
         $manifests = $bag->getTagManifests();
         $this->assertNull($manifests);
 
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . "manifest-$hash.txt");
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . "tagmanifest-$hash.txt");
+        $this->assertFileExists($bag->getBagRoot() . "/manifest-$hash.txt");
+        $this->assertFileDoesNotExist($bag->getBagRoot() . "/tagmanifest-$hash.txt");
         // Make an extended bag
         $bag->setExtended(true);
         // Tag manifest not written.
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . "tagmanifest-$hash.txt");
+        $this->assertFileDoesNotExist($bag->getBagRoot() . "/tagmanifest-$hash.txt");
 
         $bag->update();
         // Now it exists.
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . "tagmanifest-$hash.txt");
+        $this->assertFileExists($bag->getBagRoot() . "/tagmanifest-$hash.txt");
         $manifests = $bag->getTagManifests();
         $this->assertNotEmpty($manifests);
         $this->assertArrayHasKey($hash, $manifests);
@@ -274,24 +274,24 @@ class ExtendedBagTest extends BagItTestFramework
     {
         $bag = Bag::create($this->tmpdir);
         $this->assertArrayEquals(['sha512'], $bag->getAlgorithms());
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/manifest-sha512.txt');
 
         $bag->update();
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha512.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha512.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/tagmanifest-sha512.txt');
 
         $bag->setExtended(true);
         $bag->update();
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha512.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha512.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha512.txt');
 
         // Set one
         $bag->addAlgorithm('SHA1');
         // Remove it
         $bag->removeAlgorithm('SHA1');
 
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha1.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/manifest-sha1.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/tagmanifest-sha1.txt');
 
         // Set again differently
         $bag->addAlgorithm('SHA-1');
@@ -300,31 +300,31 @@ class ExtendedBagTest extends BagItTestFramework
 
         $bag->update();
 
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha1.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha1.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha1.txt');
 
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha224.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha224.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha224.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha224.txt');
 
         // Remove one
         $bag->removeAlgorithm('SHA-512');
 
         $bag->update();
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha512.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/manifest-sha512.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/tagmanifest-sha512.txt');
 
         $this->assertArrayEquals(['sha224', 'sha1'], $bag->getAlgorithms());
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha224.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha224.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha1.txt');
 
         $bag->setExtended(false);
         $bag->update();
         // tag manifests are gone.
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha224.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/tagmanifest-sha224.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/tagmanifest-sha1.txt');
         // but payload remain
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha224.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha1.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha224.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha1.txt');
     }
 
     /**
@@ -346,38 +346,38 @@ class ExtendedBagTest extends BagItTestFramework
         $this->assertArrayEquals(['sha512', 'sha1', 'sha224'], $bag->getAlgorithms());
         $bag->update();
 
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha1.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha224.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha512.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha224.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha1.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha512.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha224.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha1.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha512.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha224.txt');
 
         $bag->setAlgorithm('md5');
         $this->assertArrayEquals(['md5'], $bag->getAlgorithms());
         // Still the old manifests exist
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha1.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha224.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha512.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha224.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha1.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha512.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha224.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha1.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha512.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha224.txt');
         // And the new one doesn't
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-md5.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-md5.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/manifest-md5.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/tagmanifest-md5.txt');
 
         $bag->update();
 
         // Now the old manifests don't exist
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha1.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha224.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha512.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha224.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/manifest-sha1.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/manifest-sha512.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/manifest-sha224.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/tagmanifest-sha1.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/tagmanifest-sha512.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/tagmanifest-sha224.txt');
         // And the new one does
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-md5.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-md5.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-md5.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-md5.txt');
     }
 
     /**
@@ -394,18 +394,18 @@ class ExtendedBagTest extends BagItTestFramework
         $bag->setExtended(true);
         $bag->update();
         $this->assertArrayEquals(['sha512'], $bag->getAlgorithms());
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha512.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha512.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha512.txt');
 
         $bag->setAlgorithms(['sha1', 'SHA-224']);
         $bag->update();
         $this->assertArrayEquals(['sha1', 'sha224'], $bag->getAlgorithms());
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
-        $this->assertFileDoesNotExist($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha512.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha1.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha224.txt');
-        $this->assertFileExists($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha224.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/manifest-sha512.txt');
+        $this->assertFileDoesNotExist($bag->getBagRoot() . '/tagmanifest-sha512.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha1.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha1.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/manifest-sha224.txt');
+        $this->assertFileExists($bag->getBagRoot() . '/tagmanifest-sha224.txt');
     }
 
     /**
@@ -424,7 +424,7 @@ class ExtendedBagTest extends BagItTestFramework
         $this->assertTrue($bag->hasBagInfoTag('contact-name'));
         $tags = $bag->getBagInfoByTag('CONTACT-NAME');
         $this->assertArrayEquals(['Monty Hall'], $tags);
-        $baginfo = $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt';
+        $baginfo = $bag->getBagRoot() . '/bag-info.txt';
         $this->assertFileDoesNotExist($baginfo);
         $bag->update();
         $this->assertFileExists($baginfo);
@@ -476,7 +476,7 @@ class ExtendedBagTest extends BagItTestFramework
         $bag = Bag::create($this->tmpdir);
         $bag->setExtended(true);
         $this->assertArrayEquals([], $bag->getBagInfoData());
-        $baginfo = $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt';
+        $baginfo = $bag->getBagRoot() . '/bag-info.txt';
 
         $inputTags = [
             'Source-organization' => 'The Pyramid',
@@ -506,7 +506,7 @@ class ExtendedBagTest extends BagItTestFramework
         $bag = Bag::create($this->tmpdir);
         $bag->setExtended(true);
         $this->assertArrayEquals([], $bag->getBagInfoData());
-        $baginfo = $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt';
+        $baginfo = $bag->getBagRoot() . '/bag-info.txt';
 
         $inputTags = [
             'Source-organization' => 'The Pyramid',
@@ -580,10 +580,10 @@ class ExtendedBagTest extends BagItTestFramework
     {
         $bag = Bag::create($this->tmpdir);
         copy(
-            self::BAG_INFO_DIR . DIRECTORY_SEPARATOR . 'invalid-leading-spaces.txt',
-            $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt'
+            self::BAG_INFO_DIR . '/invalid-leading-spaces.txt',
+            $bag->getBagRoot() . '/bag-info.txt'
         );
-        touch($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-md5.txt');
+        touch($bag->getBagRoot() . '/manifest-md5.txt');
         $testbag = Bag::load($this->tmpdir);
         $this->assertCount(2, $testbag->getErrors());
     }
@@ -598,14 +598,14 @@ class ExtendedBagTest extends BagItTestFramework
     {
         $bag = Bag::create($this->tmpdir);
         copy(
-            self::BAG_INFO_DIR . DIRECTORY_SEPARATOR . 'invalid-leading-spaces.txt',
-            $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt'
+            self::BAG_INFO_DIR . '/invalid-leading-spaces.txt',
+            $bag->getBagRoot() . '/bag-info.txt'
         );
         file_put_contents(
-            $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bagit.txt',
+            $bag->getBagRoot() . '/bagit.txt',
             "BagIt-Version: 0.97" . PHP_EOL . "Tag-File-Character-Encoding: UTF-8" . PHP_EOL
         );
-        touch($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-md5.txt');
+        touch($bag->getBagRoot() . '/manifest-md5.txt');
         $testbag = Bag::load($this->tmpdir);
         $this->assertCount(0, $testbag->getErrors());
     }
@@ -730,10 +730,10 @@ class ExtendedBagTest extends BagItTestFramework
     {
         $bag = Bag::create($this->tmpdir);
         copy(
-            self::BAG_INFO_DIR . DIRECTORY_SEPARATOR . 'long-lines-and-line-returns.txt',
-            $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt'
+            self::BAG_INFO_DIR . '/long-lines-and-line-returns.txt',
+            $bag->getBagRoot() . '/bag-info.txt'
         );
-        touch($bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha512.txt');
+        touch($bag->getBagRoot() . '/manifest-sha512.txt');
 
         // Load tag values as they exist on disk. Long lines (over 70 characters) get the newline removed
         $testbag = Bag::load($this->tmpdir);
@@ -826,7 +826,7 @@ class ExtendedBagTest extends BagItTestFramework
             "tagmanifest-sha1.txt",
         ];
         foreach ($files as $file) {
-            $path = $this->tmpdir . DIRECTORY_SEPARATOR . $file;
+            $path = $this->tmpdir . '/' . $file;
             file_put_contents(
                 $path,
                 str_replace("\n", $newEnding, file_get_contents($path))
@@ -843,13 +843,13 @@ class ExtendedBagTest extends BagItTestFramework
         $this->tmpdir = $this->prepareExtendedTestBag();
         // Alter the bag-info.txt
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . 'bag-info.txt',
+            $this->tmpdir . '/bag-info.txt',
             "  the next line.\nExternal-Description: This is the start of a very long information that" .
             " is expected to wrap on to\n"
         );
         // Update the hash for bag-info.txt
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt',
+            $this->tmpdir . '/tagmanifest-sha1.txt',
             "1d9349f1fe77430540a75b996220b41d8ae571cf  bag-info.txt\n8010d7758f1793d0221c529fef818ff988dda141  " .
             "bagit.txt\nfdead00cc124f82eef20c051e699518c43adc561  manifest-sha1.txt\n" .
             "e939f78371e07a59c7a91e113618fd70cfa1e7ca  alt_tags/random_tags.txt\n"
@@ -882,14 +882,14 @@ class ExtendedBagTest extends BagItTestFramework
         $this->tmpdir = $this->prepareExtendedTestBag();
         // Alter the bag-info.txt
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . 'bag-info.txt',
+            $this->tmpdir . '/bag-info.txt',
             "External-Description: This is the start of a very long information that" .
             " is expected to wrap on to the next line eventually. This action will cause the line that comes\n" .
             "\tnext to be placed directly in line with above line, no newline."
         );
         // Update the hash for bag-info.txt
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt',
+            $this->tmpdir . '/tagmanifest-sha1.txt',
             "bec1f727e714a0821610c4a2b28f9b0ef48e086b  bag-info.txt\n8010d7758f1793d0221c529fef818ff988dda141  " .
             "bagit.txt\nfdead00cc124f82eef20c051e699518c43adc561  manifest-sha1.txt\n" .
             "e939f78371e07a59c7a91e113618fd70cfa1e7ca  alt_tags/random_tags.txt\n"
@@ -910,12 +910,12 @@ class ExtendedBagTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareExtendedTestBag();
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . "bag-info.txt",
+            $this->tmpdir . "/bag-info.txt",
             "Payload-Oxum: 19845.3\nSource-Organization: Museum of Arts and Crafts\nPayload-Oxum: 19845.3\n" .
             "External-Description: This file will fail because you can only have one payload-oxum line.\n"
         );
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt',
+            $this->tmpdir . '/tagmanifest-sha1.txt',
             "39546af37cf32cfce71b8d88a4aa4829105e11e6  bag-info.txt\n8010d7758f1793d0221c529fef818ff988dda141  " .
             "bagit.txt\nfdead00cc124f82eef20c051e699518c43adc561  manifest-sha1.txt\n" .
             "e939f78371e07a59c7a91e113618fd70cfa1e7ca  alt_tags/random_tags.txt\n"
@@ -939,13 +939,13 @@ class ExtendedBagTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareExtendedTestBag();
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . "bag-info.txt",
+            $this->tmpdir . "/bag-info.txt",
             "Payload-Oxum: 19845.3\nBag-Size: 2MB\nSource-Organization: Museum of Arts and Crafts\n" .
             "External-Description: This file will fail because you can only have one payload-oxum line.\n" .
             "Bag-Size: 2MB\n"
         );
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . 'tagmanifest-sha1.txt',
+            $this->tmpdir . '/tagmanifest-sha1.txt',
             "1a8c17edfec75662a05fad0276a08212af53c656  bag-info.txt\n8010d7758f1793d0221c529fef818ff988dda141  " .
             "bagit.txt\nfdead00cc124f82eef20c051e699518c43adc561  manifest-sha1.txt\n" .
             "e939f78371e07a59c7a91e113618fd70cfa1e7ca  alt_tags/random_tags.txt\n"

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -21,40 +21,40 @@ class FetchTest extends BagItTestFramework
     /**
      * Location of fetch file test resources.
      */
-    private const FETCH_FILES = self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'fetchFiles';
+    private const FETCH_FILES = self::TEST_RESOURCES . '/fetchFiles';
 
     /**
      * Location of webserver response files.
      */
-    private const WEBSERVER_FILES_DIR = self::TEST_RESOURCES . DIRECTORY_SEPARATOR . 'webserver_responses';
+    private const WEBSERVER_FILES_DIR = self::TEST_RESOURCES . '/webserver_responses';
 
     /**
      * Array of remote files defined in mock webserver.
      */
     private const WEBSERVER_FILES = [
         'remote_file1.txt' => [
-            'filename' => self::WEBSERVER_FILES_DIR . DIRECTORY_SEPARATOR . 'remote_file1.txt',
+            'filename' => self::WEBSERVER_FILES_DIR . '/remote_file1.txt',
             'checksums' => [
                 'sha512' => 'fd7c6f2a22f5dffac90c4483c9d623206a237a523b8e5a6f291ac0678fb6a3b5d68bb09a779c1809a15d8ef' .
                     '8c7d4e16a6d18d50c9b7f9639fd0d8fcf2b7ef46a',
             ],
         ],
         'remote_file2.txt' => [
-            'filename' => self::WEBSERVER_FILES_DIR . DIRECTORY_SEPARATOR . 'remote_file2.txt',
+            'filename' => self::WEBSERVER_FILES_DIR . '/remote_file2.txt',
             'checksums' => [
                 'sha512' => '29ad87ff27417de3e1526517e1b8583034c9f3a47e3c1f9ff216025229f9a04c85e8bdd5551d8df6838e462' .
                     '71732b98400170f8fd246d47de9312df2bdde3ca9',
             ],
         ],
         'remote_file3.txt' => [
-            'filename' => self::WEBSERVER_FILES_DIR . DIRECTORY_SEPARATOR . 'remote_file3.txt',
+            'filename' => self::WEBSERVER_FILES_DIR . '/remote_file3.txt',
             'checksums' => [
                 'sha512' => '3dccc8db74e74ba8f0d926987e6daf93f78d9d344a0babfaac5d64dd614215c5358014c830706be5f00c920' .
                     'a9ce2fec0949fababfa65f3c6b7de8a3c27ac6f96',
             ],
         ],
         'remote_file4.txt' => [
-            'filename' => self::WEBSERVER_FILES_DIR . DIRECTORY_SEPARATOR . 'remote_file4.txt',
+            'filename' => self::WEBSERVER_FILES_DIR . '/remote_file4.txt',
             'checksums' => [
                 'sha512' => '6b8c5673861b4578c441cd2fe5af209d6684abdfbaea06cbafe39e9fb1c6882b790c294d19b1d61c7504a5f' .
                     '3a916bd4266334e7f1557a3ab0ae114b0068a8c10',
@@ -127,8 +127,8 @@ class FetchTest extends BagItTestFramework
     {
         $bag = Bag::create($this->tmpdir);
         copy(
-            self::FETCH_FILES . DIRECTORY_SEPARATOR . $fetchFile,
-            $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'fetch.txt'
+            self::FETCH_FILES . '/' . $fetchFile,
+            $bag->getBagRoot() . '/fetch.txt'
         );
         return new Fetch($bag, true);
     }
@@ -286,7 +286,7 @@ class FetchTest extends BagItTestFramework
     {
         $bag = Bag::create($this->tmpdir);
         $bag->addFile(self::TEST_IMAGE['filename'], 'pretty.jpg');
-        $this->assertFileExists($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'pretty.jpg');
+        $this->assertFileExists($bag->getDataDirectory() . '/pretty.jpg');
 
         $this->expectException(BagItException::class);
         $this->expectExceptionMessage("File already exists at the destination path data/pretty.jpg");
@@ -676,7 +676,7 @@ class FetchTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareBasicTestBag();
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . "fetch.txt",
+            $this->tmpdir . "/fetch.txt",
             self::$remote_urls[4] . " 2 data/download1.jpg\n"
         );
         $bag = Bag::load($this->tmpdir);
@@ -719,7 +719,7 @@ class FetchTest extends BagItTestFramework
         }
         $bag->update();
         // Read the fetch.txt file from disk.
-        $fetch = explode("\n", file_get_contents($bag->getBagRoot() . DIRECTORY_SEPARATOR . "fetch.txt"));
+        $fetch = explode("\n", file_get_contents($bag->getBagRoot() . "/fetch.txt"));
         $fetch = array_filter($fetch);
         array_walk($fetch, function (&$o) {
             $o = trim(explode(" ", $o)[2]);

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -698,18 +698,12 @@ class FetchTest extends BagItTestFramework
     public function testCreateFetchWithEncodedCharacters(): void
     {
         $expected_on_disk = [
-            "data/file-with%0Anewline.txt",
-            "data/directory%0Dcarriage%0Dreturn/empty.txt",
             "data/image-with-%25-character.jpg",
             "data/already-encoded-%2525-double-it.txt",
-            "data/directory%0Dcarriage%0Dreturn/directory%0Aline%0Abreak/image-with-%2525.jpg",
         ];
         $expected_in_memory = [
-            "data/file-with\nnewline.txt",
-            "data/directory\rcarriage\rreturn/empty.txt",
             "data/image-with-%-character.jpg",
             "data/already-encoded-%25-double-it.txt",
-            "data/directory\rcarriage\rreturn/directory\nline\nbreak/image-with-%25.jpg",
         ];
         // Create a bag with fetch file destinations that are weird.
         $bag = Bag::create($this->tmpdir);

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -234,6 +234,7 @@ class FetchTest extends BagItTestFramework
      * @covers ::addFile
      * @covers ::download
      * @covers ::urlExistsInFile
+     * @covers ::existsInFile
      */
     public function testAddFetchUrlTwice(): void
     {
@@ -258,6 +259,7 @@ class FetchTest extends BagItTestFramework
      * @covers ::addFile
      * @covers ::download
      * @covers ::destinationExistsInFile
+     * @covers ::existsInFile
      */
     public function testAddFetchDestTwice(): void
     {

--- a/tests/FetchTest.php
+++ b/tests/FetchTest.php
@@ -408,11 +408,11 @@ class FetchTest extends BagItTestFramework
     }
 
     /**
+     * @group Fetch
      * @covers ::cleanup
      * @covers ::clearData
      * @covers ::update
      * @covers ::writeToDisk
-
      */
     public function testClearFetchFile(): void
     {

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -46,9 +46,9 @@ class ManifestTest extends BagItTestFramework
     {
         $bag = Bag::create($this->tmpdir);
         $test_files = [
-            'baginfo' => $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'bag-info.txt',
-            'payload' => $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'manifest-sha256.txt',
-            'tag' => $bag->getBagRoot() . DIRECTORY_SEPARATOR . 'tagmanifest-sha256.txt',
+            'baginfo' => $bag->getBagRoot() . '/bag-info.txt',
+            'payload' => $bag->getBagRoot() . '/manifest-sha256.txt',
+            'tag' => $bag->getBagRoot() . '/tagmanifest-sha256.txt',
         ];
         $bag->setExtended(true);
         $bag->addBagInfoTag('Contact-name', 'Jared Whiklo');
@@ -102,7 +102,7 @@ class ManifestTest extends BagItTestFramework
         $bag = Bag::load($this->tmpdir);
         $this->assertTrue($bag->isValid());
 
-        file_put_contents($bag->getDataDirectory() . DIRECTORY_SEPARATOR . 'oops.txt', "Slip up");
+        file_put_contents($bag->getDataDirectory() . '/oops.txt', "Slip up");
         $this->assertFalse($bag->isValid());
     }
 
@@ -166,7 +166,7 @@ class ManifestTest extends BagItTestFramework
         $expected = [
             "data/File-with-%0A-name.txt",
         ];
-        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "TestEncodingBag");
+        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . "/TestEncodingBag");
         $bag = Bag::load($this->tmpdir);
         $this->assertTrue($bag->isValid());
         $manifest = $bag->getPayloadManifests();
@@ -190,7 +190,7 @@ class ManifestTest extends BagItTestFramework
         $bag->addFile(self::TEST_TEXT['filename'], "already-encoded-%25-double-it.txt");
         $bag->update();
         // Read the lines from the manifest file.
-        $paths = explode("\n", file_get_contents($bag->getBagRoot() . DIRECTORY_SEPARATOR . "manifest-sha512.txt"));
+        $paths = explode("\n", file_get_contents($bag->getBagRoot() . "/manifest-sha512.txt"));
         $paths = array_filter($paths);
         array_walk($paths, function (&$o) {
             $o = trim(explode(" ", $o)[1]);
@@ -205,7 +205,7 @@ class ManifestTest extends BagItTestFramework
      */
     public function testLoadBagWithUnencodedFilepaths(): void
     {
-        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . DIRECTORY_SEPARATOR . "TestBadFilePathsBag");
+        $this->tmpdir = $this->copyTestBag(self::TEST_RESOURCES . "/TestBadFilePathsBag");
         $bag = Bag::load($this->tmpdir);
         $this->assertFalse($bag->isValid());
         // 1 errors for bad payload lines, 1 for missing files and 1 for files in the bag not in the payload manifest.
@@ -247,9 +247,8 @@ class ManifestTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareBasicTestBag();
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . 'manifest-sha256.txt',
-            file_get_contents(self::TEST_MANIFEST_DIR . DIRECTORY_SEPARATOR .
-                $manifest_filename)
+            $this->tmpdir . '/manifest-sha256.txt',
+            file_get_contents(self::TEST_MANIFEST_DIR . '/' . $manifest_filename)
         );
     }
 
@@ -277,7 +276,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareBasicTestBag();
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . "manifest-sha256.txt",
+            $this->tmpdir . "/manifest-sha256.txt",
             "3663a4f1d58f56248bf3708a27c1f143a9ec96ea5dbb78d627a4330b73f8b6db  data/jekyll_and_hyde.txt\n" .
             "0fd56c020e20bf86fd89b3357b30203c684411afca5c7aa98023f32f7536e936  data/pictures/another_picture.txt\n" .
             "2c9d71a5db0a38b99b897f2397f7e252f451a7d219d044a47f22ffd3637e64e3  data/pictures/some_more_data.txt\n" .
@@ -300,7 +299,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareBasicTestBag();
         file_put_contents(
-            $this->tmpdir . DIRECTORY_SEPARATOR . "manifest-sha256.txt",
+            $this->tmpdir . "/manifest-sha256.txt",
             "3663a4f1d58f56248bf3708a27c1f143a9ec96ea5dbb78d627a4330b73f8b6db  data/jekyll_and_hyde.txt\n" .
             "0fd56c020e20bf86fd89b3357b30203c684411afca5c7aa98023f32f7536e936  data/../../pictures/" .
             "another_picture.txt\n2c9d71a5db0a38b99b897f2397f7e252f451a7d219d044a47f22ffd3637e64e3  " .
@@ -313,7 +312,7 @@ class ManifestTest extends BagItTestFramework
             "another_picture.txt"
         ];
         // Delete the file from the bag that we are referencing as outside the bag.
-        unlink(implode(DIRECTORY_SEPARATOR, $path));
+        unlink(implode('/', $path));
         $bag = Bag::load($this->tmpdir);
         $this->assertFalse($bag->isValid());
         $this->assertCount(1, $bag->getErrors());

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -100,7 +100,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareExtendedTestBag();
         $bag = Bag::load($this->tmpdir);
-        var_dump($bag->getErrors());
+        var_export($bag->getErrors());
         $this->assertTrue($bag->isValid());
 
         file_put_contents($bag->getDataDirectory() . '/oops.txt', "Slip up");
@@ -119,7 +119,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->prepareManifest('manifest-with-relative-paths-sha256.txt');
         $bag = Bag::load($this->tmpdir);
-        var_dump($bag->getErrors());
+        var_export($bag->getErrors());
         $this->assertTrue($bag->isValid());
         $this->assertCount(0, $bag->getErrors());
         $this->assertCount(1, $bag->getWarnings());

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -100,6 +100,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareExtendedTestBag();
         $bag = Bag::load($this->tmpdir);
+        var_dump($bag->getErrors());
         $this->assertTrue($bag->isValid());
 
         file_put_contents($bag->getDataDirectory() . '/oops.txt', "Slip up");
@@ -118,6 +119,7 @@ class ManifestTest extends BagItTestFramework
     {
         $this->prepareManifest('manifest-with-relative-paths-sha256.txt');
         $bag = Bag::load($this->tmpdir);
+        var_dump($bag->getErrors());
         $this->assertTrue($bag->isValid());
         $this->assertCount(0, $bag->getErrors());
         $this->assertCount(1, $bag->getWarnings());

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -100,7 +100,6 @@ class ManifestTest extends BagItTestFramework
     {
         $this->tmpdir = $this->prepareExtendedTestBag();
         $bag = Bag::load($this->tmpdir);
-        var_export($bag->getErrors());
         $this->assertTrue($bag->isValid());
 
         file_put_contents($bag->getDataDirectory() . '/oops.txt', "Slip up");
@@ -119,7 +118,6 @@ class ManifestTest extends BagItTestFramework
     {
         $this->prepareManifest('manifest-with-relative-paths-sha256.txt');
         $bag = Bag::load($this->tmpdir);
-        var_export($bag->getErrors());
         $this->assertTrue($bag->isValid());
         $this->assertCount(0, $bag->getErrors());
         $this->assertCount(1, $bag->getWarnings());


### PR DESCRIPTION
Switches to using `/` as file path separator internally for all OS'es.
Fixes to get Windows to pass tests.