### PR TITLE
Drop curl_close() as it's deprecated in PHP 8.5 and does nothing since 8.0

### DIFF
--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -404,7 +404,6 @@ class Fetch
                     $this->saveFileData($content, $destinations[$x]);
                 }
                 curl_multi_remove_handle($mh, $curl_handles[$x]);
-                curl_close($curl_handles[$x]);
             }
             curl_multi_close($mh);
         }


### PR DESCRIPTION
Drop `curl_close()` from `src/Fetch.php` call as since PHP 8.0 the `curl_close()` has no effect and it become deprecated in PHP 8.5 (see https://www.php.net/manual/en/function.curl-close.php) and the minimum required PHP version of the bagit library is 8.2.